### PR TITLE
Bugfix for Wkl.svg()

### DIFF
--- a/tests/test_geometry_access.py
+++ b/tests/test_geometry_access.py
@@ -1,0 +1,38 @@
+import json
+
+import pytest
+
+import wkls
+
+
+@pytest.fixture
+def sf() -> wkls.Wkl:
+    # noinspection PyUnresolvedReferences
+    return wkls.us.ca.sanfrancisco
+
+
+def test_wkt(sf):
+    geom = sf.wkt()
+    assert isinstance(geom, str)
+    assert geom.startswith("MULTIPOLYGON")
+
+
+def test_wkb(sf):
+    geom = sf.wkb()
+    assert isinstance(geom, bytearray)
+
+
+def test_hexwkb(sf):
+    geom = sf.hexwkb()
+    assert isinstance(geom, str)
+
+
+def test_geojson(sf):
+    geom = sf.geojson()
+    geom = json.loads(geom)
+    assert isinstance(geom, dict)
+
+
+def test_svg(sf):
+    geom = sf.svg()
+    assert isinstance(geom, str)

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -237,8 +237,10 @@ class Wkl:
     def geojson(self):
         return self._get_geom_expr("ST_AsGeoJSON(geometry)")
 
-    def svg(self):
-        return self._get_geom_expr("ST_AsSVG(geometry)")
+    def svg(self, relative: bool = False, precision: int = 15):
+        return self._get_geom_expr(
+            f"ST_AsSVG(geometry, {str(relative).lower()}, {precision})"
+        )
 
     def countries(self):
         if self.chain:


### PR DESCRIPTION
Add missing parameters to `ST_AsSVG` function call

See: https://duckdb.org/docs/stable/core_extensions/spatial/functions.html#st_assvg

Also add basic test suite for geometry export methods