### PR TITLE
Use hugging face as dataset source

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `wkls` makes it easy to find global administrative boundaries — from countries to cities — using readable, chainable Python syntax.
 
-It reads [Overture Maps Foundation](https://overturemaps.org/) GeoParquet data (version 2025-09-24.0) directly from the AWS Open Data Registry.
+It fetches geometries from a mirror of [Overture Maps Foundation](https://overturemaps.org/) GeoParquet data (version 2025-11-19.0) hosted on HuggingFace.
 
 You can instantly get geometries in formats like Well-known Text (WKT), Well-known Binaries (WKB), HexWKB, GeoJSON, and SVG:
 
@@ -14,7 +14,7 @@ import wkls
 # prints "MULTIPOLYGON (((-122.5279985 37.8155806...)))"
 print(wkls.us.ca.sanfrancisco.wkt())
 
-#prints "2025-09-24.0"
+#prints "2025-11-19.0"
 print(wkls.overture_version())
 ```
 

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 # Overture Maps dataset version
 OVERTURE_VERSION = "2025-11-19.0"
-S3_PARQUET_PATH = f"s3://overturemaps-us-west-2/release/{OVERTURE_VERSION}/theme=divisions/type=division_area/*"
+HF_PARQUET_PATH = f"hf://datasets/wherobots/overturemaps-us-west-2/release/{OVERTURE_VERSION}/theme=divisions/type=division_area/*"
 
 COUNTRY_DEPENDENCY_QUERY = """
     SELECT * FROM wkls
@@ -270,7 +270,7 @@ class Wkl:
         geom_id = df.iloc[0]["id"]
         query = f"""
             SELECT {expr}
-            FROM parquet_scan('{S3_PARQUET_PATH}')
+            FROM parquet_scan('{HF_PARQUET_PATH}')
             WHERE id = '{geom_id}'
         """
         result_df = duckdb.sql(query).df()


### PR DESCRIPTION
Overture maintains only the two most recent releases in the AWS Open Registry. This forces `wkls` to follow the same release cadence as overture datasets. 
For better control and to avoid deprecation issues, we've hosted a mirror of the latest (2025-11-19.0) Overture Divisions theme on Hugging Face (https://huggingface.co/datasets/wherobots/overturemaps-us-west-2). 

This is a temporary solution until Overture's GERSIDs are stable enough to allow release version independent access using stable GERSIDs