### PR TITLE
Enable interactive mode for auto-display of DataFrames

### DIFF
--- a/wkls/core.py
+++ b/wkls/core.py
@@ -107,6 +107,9 @@ def _initialize_table() -> sedonadb.SedonaContext:
     """
     sedona = sedonadb.connect()
 
+    # Enable interactive mode for auto-display
+    sedona.options.interactive = True
+
     # Monkey-patch `.sql()` for debug mode.
     sedona_sql = sedona.sql
     sedona.sql = lambda q: _log_and_query(sedona_sql, q)


### PR DESCRIPTION
Enable SedonaDB's interactive mode to automatically display DataFrame contents in notebooks and REPLs without requiring explicit `.show()` calls.

Before:

```
>>> wkls.us.ca
<wkls.core.ChainableDataFrame object at 0x13111a1b0>
```

After:

```
>>> wkls.us.ca
┌────────────────────────┬─────────┬────────┬─────────┬──────────────┬────────────┐
│           id           ┆ country ┆ region ┆ subtype ┆ name_primary ┆   name_en  │
╞════════════════════════╪═════════╪════════╪═════════╪══════════════╪════════════╡
│ ae9174cc-9008-4231-86… ┆ US      ┆ US-CA  ┆ region  ┆ California   ┆ California │
└────────────────────────┴─────────┴────────┴─────────┴──────────────┴────────────┘
```