### PR TITLE
Refactor: Reduce code duplication and cache country region checks

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -59,7 +59,9 @@ def test_counties_chaining_errors():
     # counties() on root should fail
     with pytest.raises(ValueError) as exc_info:
         wkls.counties()
-    assert "counties() requires exactly one or two levels of chaining" in str(exc_info.value)
+    assert "counties() requires exactly one or two levels of chaining" in str(
+        exc_info.value
+    )
     assert "wkls.country.region.counties()" in str(exc_info.value)
 
     # counties() on country only should fail
@@ -71,7 +73,9 @@ def test_counties_chaining_errors():
     # counties() on country.region.city should fail
     with pytest.raises(ValueError) as exc_info:
         wkls.us.ca.sanfrancisco.counties()
-    assert "counties() requires exactly one or two levels of chaining" in str(exc_info.value)
+    assert "counties() requires exactly one or two levels of chaining" in str(
+        exc_info.value
+    )
 
 
 def test_cities_chaining_errors():
@@ -79,7 +83,9 @@ def test_cities_chaining_errors():
     # cities() on root should fail
     with pytest.raises(ValueError) as exc_info:
         wkls.cities()
-    assert "cities() requires exactly one or two levels of chaining" in str(exc_info.value)
+    assert "cities() requires exactly one or two levels of chaining" in str(
+        exc_info.value
+    )
     assert "wkls.country.region.cities()" in str(exc_info.value)
 
     # cities() on country only should fail
@@ -90,7 +96,9 @@ def test_cities_chaining_errors():
     # cities() on country.region.city should fail
     with pytest.raises(ValueError) as exc_info:
         wkls.us.ca.sanfrancisco.cities()
-    assert "cities() requires exactly one or two levels of chaining" in str(exc_info.value)
+    assert "cities() requires exactly one or two levels of chaining" in str(
+        exc_info.value
+    )
 
 
 def test_subtypes_chaining_error():

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -149,10 +149,21 @@ def sqlescape(v: str) -> str:
 
 
 # Methods that ChainableDataFrame delegates to Wkl
-_WKL_DELEGATED_METHODS = frozenset({
-    "wkt", "wkb", "hexwkb", "geojson", "svg",
-    "dependencies", "countries", "regions", "counties", "cities", "subtypes",
-})
+_WKL_DELEGATED_METHODS = frozenset(
+    {
+        "wkt",
+        "wkb",
+        "hexwkb",
+        "geojson",
+        "svg",
+        "dependencies",
+        "countries",
+        "regions",
+        "counties",
+        "cities",
+        "subtypes",
+    }
+)
 
 
 class ChainableDataFrame(sedonadb.dataframe.DataFrame):
@@ -636,9 +647,7 @@ class Wkl:
               AND subtype IN {subtype_filter}
         """
         return sedona.sql(
-            query.format(
-                country=sqlescape(country_iso), region=sqlescape(region_iso)
-            )
+            query.format(country=sqlescape(country_iso), region=sqlescape(region_iso))
         )
 
     def counties(self) -> sedonadb.dataframe.DataFrame:


### PR DESCRIPTION
Cleans up core.py by removing duplicated code and adding a simple performance optimization.

Changes:

- Dynamic method delegation - `ChainableDataFrame` now delegates to `Wkl` via `__getattr__` instead of 11 separate wrapper methods
- Cache `_has_region` checks - Store results in a module-level dict to avoid repeated SQL queries for the same country
- Extract helper methods - `_get_subdivisions()` for counties/cities
- Simplify conditionals - Remove redundant branches in `regions()`, `counties()`, `cities()`

