### PR TITLE
Add Arrow PyCapsule protocol support for Wkl and ChainableDataFrame

### DIFF
--- a/tests/test_geometry_access.py
+++ b/tests/test_geometry_access.py
@@ -45,6 +45,7 @@ def test_svg(sf):
         geom = sf.svg()
         assert isinstance(geom, str)
 
+
 def test_arrow(sf):
     pa = pytest.importorskip("pyarrow")
     assert hasattr(sf, "__arrow_c_array__")
@@ -52,6 +53,7 @@ def test_arrow(sf):
     assert len(array) == 1
     assert array.type.extension_name == "geoarrow.wkb"
     assert array.storage[0].as_py() == sf.wkb()
+
 
 def test_countries_without_region(stoneyridge):
     geom = stoneyridge.wkt()

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -361,9 +361,7 @@ class ChainableDataFrame:
         return super().__getitem__(key)
 
     def __arrow_c_array__(self, requested_schema=None):
-        return Wkl(self._chain).__arrow_c_array__(
-            requested_schema=requested_schema
-        )
+        return Wkl(self._chain).__arrow_c_array__(requested_schema=requested_schema)
 
     @property
     def _constructor(self) -> type[ChainableDataFrame]:
@@ -864,9 +862,7 @@ class Wkl:
 
         wkb_bytes = self.wkb()
         pyarrow_wkb_array = ga.with_crs([wkb_bytes], crs=ga.OGC_CRS84)
-        return pyarrow_wkb_array.__arrow_c_array__(
-            requested_schema=requested_schema
-        )
+        return pyarrow_wkb_array.__arrow_c_array__(requested_schema=requested_schema)
 
     def dependencies(self) -> sedonadb.dataframe.DataFrame:
         """Get all dependencies (territories, overseas regions, etc.).


### PR DESCRIPTION
This PR adds the `__arrow_c_array__` protocol method to Wkl and ChainableDataFrame objects, which means they will work out of the box in places like `pyarrow.array()` and `sd.sql(..., params=...)` without the user having to explicitly set the CRS.