### PR TITLE
feat: .search(), __dir__ discovery, subtree-scoped listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ wkls.us.ca.sanfrancisco.wkt()
 # "MULTIPOLYGON (((-122.5279985 37.8155806...)))"
 ```
 
-- Chainable attribute access to countries, states, counties, and cities
+- Chainable attribute access by ISO code *or* English name (`wkls.us.ca.sanfrancisco`, `wkls.india.maharashtra`)
+- `.search("query")` at any chain level — scoped to the current subtree
 - Precise geometries from [Overture Maps Foundation](https://overturemaps.org/) — no bounding boxes, no shapefiles
 - Outputs boundaries in WKT, WKB, or GeoJSON
 - Support for HexWKB and SVG planned
@@ -69,22 +70,40 @@ wkls.de.geojson()  # GeoJSON string
 
 ### Exploring the dataset
 
+Listing methods scope to the current chain, all the way up to the dataset root:
+
 ```python
 wkls.countries()       # all countries
 wkls.dependencies()    # all dependencies
+wkls.regions()         # every region worldwide
+wkls.counties()        # every county worldwide
+wkls.cities()          # every city worldwide
+
 wkls.us.regions()      # regions in the US
+wkls.us.counties()     # every county in the US
+wkls.us.cities()       # every city in the US
+
 wkls.us.ca.counties()  # counties in California
 wkls.us.ca.cities()    # cities in California
-wkls.fk.cities()       # countries without regions work too
 ```
 
-### Wildcard search
+`dir(wkls)` and `dir(wkls.us)` list every attribute that resolves at that
+level — both ISO codes and English names — for interactive exploration
+and tab completion.
 
-Use `%` for pattern matching when you're not sure of the exact name:
+### Search
+
+`.search(query)` finds every row whose name contains the query substring.
+Scope narrows with chain depth:
 
 ```python
-wkls.us.ca["%francis%"]  # matches "San Francisco"
+wkls.search("san francisco")        # anywhere in the dataset
+wkls.us.search("san francisco")     # anywhere in the US
+wkls.us.ca.search("san francisco")  # anywhere in California
 ```
+
+Results come back as a DataFrame with a `subtype` column, so callers can
+filter countries from cities easily.
 
 ### Pinning an Overture version
 
@@ -105,19 +124,18 @@ export WKLS_OVERTURE_VERSION=2025-12-17.0
 
 Priority: `configure()` > environment variable > auto-detect.
 
-### Bracket access
+### Bracket access (deprecated)
 
-Most keyword/numeric collisions are resolved by name access (`wkls.austria.burgenland`
-instead of `wkls.at["1"]`). Bracket syntax is still available on chained objects for
-the rare cases where attribute access collides with a DataFrame method:
+Bracket access (`wkls.us["ne"]`, `wkls.us.ca["%fran%"]`) still works but
+emits a `DeprecationWarning` pointing at the modern replacement:
 
-```python
-wkls.us["ne"].wkt()     # Nebraska (wkls.us.ne would call DataFrame.ne)
-wkls.us.ca["%fran%"]    # wildcard search
-```
+- Keyword / numeric collisions → use the English name:
+  `wkls.us.nebraska`, `wkls.austria.burgenland`.
+- Wildcard search → use `.search()`:
+  `wkls.us.ca.search("fran")`.
 
-Bracket access at the module root (`wkls["..."]`) is not supported — real Python
-modules aren't subscriptable. Use dot access or `Wkl()["..."]` instead.
+Bracket access at the module root (`wkls["..."]`) is not supported — real
+Python modules aren't subscriptable. Use dot access or `Wkl()["..."]`.
 
 ## How it works
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest fixtures shared across the test suite."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+
+@pytest.fixture
+def ignore_bracket_deprecation():
+    """Silence DeprecationWarning emitted by legacy __getitem__ calls.
+
+    Used by tests that exercise bracket access on purpose — for example,
+    regression tests asserting the shim still works, or older tests that
+    predate the `.search()` / name-access migration.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Bracket access.*deprecated",
+            category=DeprecationWarning,
+        )
+        yield

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -137,7 +137,7 @@ def test_nonexistent_location_errors():
         pass  # Could be various exceptions depending on validation
 
     # Nonexistent city with search pattern (this should return empty results)
-    result = wkls.us.ca["%nonexistentcity%"]
+    result = wkls.us.ca.search("nonexistentcity")
     assert result.count() == 0, "Nonexistent city search should return empty DataFrame"
 
 
@@ -180,8 +180,8 @@ def test_did_you_mean_country_level():
     assert "No results found for: u" in repr_str
     assert "Did you mean:" in repr_str
     assert "us" in repr_str
-    # Verify wildcard tip has correct syntax for root level
-    assert "wkls['%u%']" in repr_str
+    # Verify search tip has correct syntax for root level
+    assert "wkls.search('u')" in repr_str
 
 
 def test_suggestions_for_extended_codes():
@@ -203,7 +203,7 @@ def test_no_suggestions_for_unrelated_codes():
     # No suggestions since no code starts with "xyz" and "xyz" doesn't start with any code
     assert "Did you mean:" not in repr_str
     # But wildcard tip is still shown
-    assert "wkls.us['%xyz%']" in repr_str
+    assert "wkls.us.search('xyz')" in repr_str
 
 
 def test_did_you_mean_partial_match():
@@ -269,14 +269,14 @@ def test_suggestions_in_repr():
     assert "No results found for: us.ca.sanfran" in repr_str
     assert "Did you mean:" in repr_str
     assert "sanfrancisco" in repr_str
-    assert "wkls.us.ca['%sanfran%']" in repr_str
+    assert "wkls.us.ca.search('sanfran')" in repr_str
 
 
-def test_suggestions_in_repr_bracket_access():
+def test_suggestions_in_repr_bracket_access(ignore_bracket_deprecation):
     """Test that suggestions appear when using bracket access."""
     # Access a non-existent country using bracket syntax on a Wkl instance.
-    # The module itself is no longer subscriptable (PEP 562 compliant); use
-    # Wkl() for bracket access if needed.
+    # Bracket access is deprecated but must still work as a shim — that's
+    # exactly what this test guards against regressing.
     from wkls import Wkl
 
     result = Wkl()["uss"]
@@ -284,7 +284,7 @@ def test_suggestions_in_repr_bracket_access():
     assert "No results found for: uss" in repr_str
     assert "Did you mean:" in repr_str
     assert "us" in repr_str
-    assert "wkls['%uss%']" in repr_str
+    assert "wkls.search('uss')" in repr_str
 
 
 def test_chainable_dataframe_error_propagation():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,11 +4,10 @@ import wkls
 
 
 def test_countries_without_region():
-    with pytest.raises(ValueError) as exc_info:
-        wkls.fk.regions()
-    assert "The country 'FK' does not have regions in the dataset" in str(
-        exc_info.value
-    )
+    """Countries with no regions return an empty DataFrame, not an error."""
+    # Regions now scope to a subtree; countries like FK that have no region
+    # rows simply return zero — no longer a special error case.
+    assert wkls.fk.regions().count() == 0
 
 
 def test_empty_chain_error():
@@ -40,65 +39,32 @@ def test_countries_chaining_error():
     assert "wkls.countries()" in str(exc_info.value)
 
 
-def test_regions_chaining_errors():
-    """Test regions() validation errors."""
-    # regions() on root should fail
+def test_regions_at_region_level_returns_self():
+    """regions() at region level returns the region itself — the only region row in that scope."""
+    df = wkls.us.ca.regions().to_arrow_table()
+    assert df.num_rows == 1
+    assert df.column("region")[0].as_py() == "US-CA"
+
+
+def test_regions_past_region_level_raises():
+    """regions() past region level raises (depth 3 has no subtree)."""
     with pytest.raises(ValueError) as exc_info:
-        wkls.regions()
-    assert "regions() requires exactly one level of chaining" in str(exc_info.value)
-    assert "wkls.<country>.regions()" in str(exc_info.value)
-
-    # regions() on country.region should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.us.ca.regions()
-    assert "regions() requires exactly one level of chaining" in str(exc_info.value)
+        wkls.us.ca.sanfrancisco.regions()
+    assert "past region level" in str(exc_info.value)
 
 
-def test_counties_chaining_errors():
-    """Test counties() validation errors."""
-    # counties() on root should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.counties()
-    assert "counties() requires exactly one or two levels of chaining" in str(
-        exc_info.value
-    )
-    assert "wkls.<country>.<region>.counties()" in str(exc_info.value)
-
-    # counties() on country only should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.us.counties()
-    assert "counties() cannot be called on a country alone" in str(exc_info.value)
-    assert "wkls.<country>.<region>.counties()" in str(exc_info.value)
-
-    # counties() on country.region.city should fail
+def test_counties_past_region_level_raises():
+    """counties() past region level raises (depth 3 has no subtree)."""
     with pytest.raises(ValueError) as exc_info:
         wkls.us.ca.sanfrancisco.counties()
-    assert "counties() requires exactly one or two levels of chaining" in str(
-        exc_info.value
-    )
+    assert "past region level" in str(exc_info.value)
 
 
-def test_cities_chaining_errors():
-    """Test cities() validation errors."""
-    # cities() on root should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.cities()
-    assert "cities() requires exactly one or two levels of chaining" in str(
-        exc_info.value
-    )
-    assert "wkls.<country>.<region>.cities()" in str(exc_info.value)
-
-    # cities() on country only should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.us.cities()
-    assert "cities() cannot be called on a country alone" in str(exc_info.value)
-
-    # cities() on country.region.city should fail
+def test_cities_past_region_level_raises():
+    """cities() past region level raises (depth 3 has no subtree)."""
     with pytest.raises(ValueError) as exc_info:
         wkls.us.ca.sanfrancisco.cities()
-    assert "cities() requires exactly one or two levels of chaining" in str(
-        exc_info.value
-    )
+    assert "past region level" in str(exc_info.value)
 
 
 def test_subtypes_chaining_error():
@@ -297,11 +263,9 @@ def test_chainable_dataframe_error_propagation():
         us_data.countries()
     assert "countries() can only be called on the root object" in str(exc_info.value)
 
-    # regions() should fail on chained data (more than 1 level)
+    # regions() on a region-level chain returns the region itself.
     ca_data = wkls.us.ca
-    with pytest.raises(ValueError) as exc_info:
-        ca_data.regions()
-    assert "regions() requires exactly one level of chaining" in str(exc_info.value)
+    assert ca_data.regions().count() == 1
 
 
 def test_version_attribute():
@@ -323,9 +287,10 @@ def test_dunder_attributes_raise_attribute_error():
 if __name__ == "__main__":
     test_empty_chain_error()
     test_countries_chaining_error()
-    test_regions_chaining_errors()
-    test_counties_chaining_errors()
-    test_cities_chaining_errors()
+    test_regions_at_region_level_returns_self()
+    test_regions_past_region_level_raises()
+    test_counties_past_region_level_raises()
+    test_cities_past_region_level_raises()
     test_subtypes_chaining_error()
     test_too_many_chained_attributes()
     test_nonexistent_location_errors()

--- a/tests/test_llm_usability.py
+++ b/tests/test_llm_usability.py
@@ -229,18 +229,46 @@ def test_dir_cached_no_query_on_repeat(capsys):
 # ---------- Stream 2: .search() ----------
 
 
-def test_search_root_returns_countries():
-    """wkls.search() at root returns a DataFrame of matching countries/dependencies."""
-    df = wkls.search("united")
-    assert df.count() >= 3  # US, UK, UAE, at minimum
+def test_search_root_returns_mixed_subtypes():
+    """wkls.search() at root scans every subtype, not just countries."""
+    df = wkls.search("san francisco").to_arrow_table()
+    subtypes = {df.column("subtype")[i].as_py() for i in range(df.num_rows)}
+    # There's no country named San Francisco but many cities and counties;
+    # the result should include city-like subtypes.
+    assert subtypes & {"locality", "localadmin", "county"}, (
+        f"Expected city-like subtypes, got {subtypes}"
+    )
 
 
-def test_search_country_returns_regions():
-    """search() at country level returns matching regions."""
-    df = wkls.us.search("new")
-    table = df.to_arrow_table()
-    names = {table.column("name_primary")[i].as_py() for i in range(table.num_rows)}
-    assert {"New Hampshire", "New Jersey", "New Mexico", "New York"}.issubset(names)
+def test_search_finds_city_from_root():
+    """A root-level search for a city name returns the actual city."""
+    df = wkls.search("san francisco").to_arrow_table()
+    matches = [
+        (df.column("country")[i].as_py(), df.column("name_primary")[i].as_py())
+        for i in range(df.num_rows)
+    ]
+    assert ("US", "San Francisco") in matches
+
+
+def test_search_country_scope_expands():
+    """search() under a country now finds cities, not just regions."""
+    df = wkls.us.search("los angeles").to_arrow_table()
+    subtypes = {df.column("subtype")[i].as_py() for i in range(df.num_rows)}
+    # Expect the locality + county + any region-level match.
+    assert subtypes & {"locality", "county"}
+
+
+def test_search_country_finds_regions_too():
+    """Country-level search still returns region matches alongside cities."""
+    df = wkls.us.search("new").to_arrow_table()
+    names_by_subtype = {
+        (df.column("subtype")[i].as_py(), df.column("name_primary")[i].as_py())
+        for i in range(df.num_rows)
+    }
+    region_names = {n for st, n in names_by_subtype if st == "region"}
+    assert {"New Hampshire", "New Jersey", "New Mexico", "New York"}.issubset(
+        region_names
+    )
 
 
 def test_search_region_returns_cities():
@@ -253,10 +281,9 @@ def test_search_region_returns_cities():
 
 
 def test_search_no_region_country():
-    """search() works on countries without regions (e.g., FK)."""
+    """search() on countries without regions scopes to that country."""
     df = wkls.fk.search("stanley")
-    # FK has no regions, so this exercises SEARCH_CITIES_NO_REGION.
-    # Accept zero-or-more matches — dataset may vary across Overture releases.
+    # FK has no regions; depth-1 search filters by country only.
     assert df is not None
 
 

--- a/tests/test_llm_usability.py
+++ b/tests/test_llm_usability.py
@@ -1,13 +1,15 @@
-"""Golden tests for Phase 1 LLM/agent usability work.
+"""Golden tests for LLM/agent usability work.
 
-Covers PEP 562 dual import, name-based country/region resolution and
-the _country_info cache, and docstring smoke coverage.
+Covers PEP 562 dual import, name-based country/region resolution,
+the _country_info cache, docstring smoke coverage, __dir__ overrides,
+.search(), and deprecation of bracket access.
 """
 
 from __future__ import annotations
 
 import os
 import types
+import warnings
 
 import pytest
 
@@ -171,3 +173,168 @@ def test_cache_query_count(cold_caches, capsys):
         "SELECT * FROM wkls\n    WHERE country = 'US'\n      AND subtype = 'region'"
         not in second_out
     )
+
+
+# ---------- Stream 3: __dir__ overrides ----------
+
+
+def test_dir_root_both_forms():
+    """dir(wkls) exposes both ISO codes and names for countries."""
+    entries = dir(wkls)
+    assert "us" in entries
+    assert "unitedstates" in entries
+    assert "in" in entries
+    assert "india" in entries
+    assert "Wkl" in entries  # module attrs still present
+
+
+def test_dir_country_level_both_forms():
+    """dir(wkls.us) exposes both region ISO suffixes and region names."""
+    entries = dir(wkls.us)
+    assert "ca" in entries
+    assert "california" in entries
+    assert "or" in entries
+    assert "oregon" in entries
+    assert "regions" in entries  # method still present
+
+
+def test_dir_region_level_methods_only():
+    """dir(wkls.us.ca) returns methods only — no city identifiers."""
+    entries = dir(wkls.us.ca)
+    assert set(entries) == {"cities", "counties", "geojson", "search", "wkb", "wkt"}
+
+
+def test_dir_city_level_geometry_methods_only():
+    """dir on a resolved city returns geometry-output methods."""
+    entries = dir(wkls.us.ca.sanfrancisco)
+    assert set(entries) == {"geojson", "wkb", "wkt"}
+
+
+def test_dir_cached_no_query_on_repeat(capsys):
+    """Second dir() call at the same level fires zero SQL queries."""
+    core._dir_cache.clear()
+    os.environ["WKLS_DEBUG"] = "true"
+    try:
+        dir(wkls)
+        first_out = capsys.readouterr().out
+        dir(wkls)
+        second_out = capsys.readouterr().out
+    finally:
+        del os.environ["WKLS_DEBUG"]
+
+    assert "subtype IN ('country', 'dependency')" in first_out
+    assert "SELECT DISTINCT" not in second_out
+
+
+# ---------- Stream 2: .search() ----------
+
+
+def test_search_root_returns_countries():
+    """wkls.search() at root returns a DataFrame of matching countries/dependencies."""
+    df = wkls.search("united")
+    assert df.count() >= 3  # US, UK, UAE, at minimum
+
+
+def test_search_country_returns_regions():
+    """search() at country level returns matching regions."""
+    df = wkls.us.search("new")
+    table = df.to_arrow_table()
+    names = {table.column("name_primary")[i].as_py() for i in range(table.num_rows)}
+    assert {"New Hampshire", "New Jersey", "New Mexico", "New York"}.issubset(names)
+
+
+def test_search_region_returns_cities():
+    """search() at region level returns matching cities/counties."""
+    df = wkls.us.ca.search("san fran")
+    assert df.count() >= 1
+    table = df.to_arrow_table()
+    names = [table.column("name_primary")[i].as_py() for i in range(table.num_rows)]
+    assert any("San Francisco" in n for n in names)
+
+
+def test_search_no_region_country():
+    """search() works on countries without regions (e.g., FK)."""
+    df = wkls.fk.search("stanley")
+    # FK has no regions, so this exercises SEARCH_CITIES_NO_REGION.
+    # Accept zero-or-more matches — dataset may vary across Overture releases.
+    assert df is not None
+
+
+def test_search_too_deep_raises():
+    """search() past city level raises ValueError."""
+    with pytest.raises(ValueError, match="past city level"):
+        wkls.us.ca.sanfrancisco.search("foo")
+
+
+# ---------- Region-name resolution regression ----------
+
+
+def test_counties_via_name_chain():
+    """wkls.india.maharashtra.counties() should return the same count as IN-MH."""
+    assert wkls.india.maharashtra.counties().count() >= 1
+    # Matches the ISO path — both identifiers resolve to IN-MH.
+    from_name = wkls.india.maharashtra.counties().count()
+    from_iso = wkls.IN.MH.counties().count()
+    assert from_name == from_iso
+
+
+def test_cities_via_name_chain():
+    """Name-based chain supports cities()."""
+    from_name = wkls.india.maharashtra.cities().count()
+    from_iso = wkls.IN.MH.cities().count()
+    assert from_name == from_iso >= 1
+
+
+# ---------- __getitem__ deprecation ----------
+
+
+def test_bracket_access_emits_deprecation():
+    """Wkl()[...] still works but emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="Bracket access is deprecated"):
+        result = Wkl()["IN"]
+    assert result._df.to_arrow_table().column("country")[0].as_py() == "IN"
+
+
+def test_bracket_wildcard_emits_deprecation_pointing_to_search():
+    """Wildcard bracket access warns and suggests .search()."""
+    with pytest.warns(
+        DeprecationWarning, match=r"wildcards is deprecated; use \.search\('fran'\)"
+    ):
+        result = wkls.us.ca["%fran%"]
+    assert result.count() >= 1
+
+
+def test_chainable_bracket_emits_deprecation():
+    """ChainableDataFrame[...] also warns."""
+    with pytest.warns(DeprecationWarning, match="Bracket access is deprecated"):
+        wkls.us["CA"]
+
+
+def test_chainable_list_index_does_not_warn():
+    """DataFrame-style list indexing on ChainableDataFrame does NOT emit the warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        # A plain DataFrame-column list select should not trip the location-access warning.
+        # If this raises, it's the underlying DataFrame behavior, not our deprecation.
+        try:
+            wkls.us.ca[["id", "country"]]
+        except DeprecationWarning:
+            pytest.fail("DataFrame-style indexing should not emit DeprecationWarning")
+        except Exception:
+            pass  # Any other exception is fine — we're only testing the warning.
+
+
+# ---------- Error-hint migration ----------
+
+
+def test_error_hint_uses_search_not_brackets():
+    """Empty-result hint points at .search(), not bracket wildcards."""
+    repr_str = repr(wkls.us.ca.nonexistentcity)
+    assert "wkls.us.ca.search('nonexistentcity')" in repr_str
+    assert "['%" not in repr_str
+
+
+def test_error_hint_at_root_uses_search():
+    """Root-level empty result hints at wkls.search()."""
+    repr_str = repr(wkls.zz)
+    assert "wkls.search('zz')" in repr_str

--- a/tests/test_llm_usability.py
+++ b/tests/test_llm_usability.py
@@ -293,6 +293,55 @@ def test_search_too_deep_raises():
         wkls.us.ca.sanfrancisco.search("foo")
 
 
+# ---------- List methods: subtree-scoped regions/counties/cities ----------
+
+
+def test_regions_at_root_returns_all():
+    """wkls.regions() at root returns every region worldwide."""
+    count = wkls.regions().count()
+    # Dataset has ~3,900 regions; use a generous lower bound to stay resilient
+    # across Overture releases.
+    assert count > 3000
+
+
+def test_regions_scoped_to_country():
+    """wkls.us.regions() returns regions scoped to that country."""
+    assert wkls.us.regions().count() == 51  # 50 states + DC
+
+
+def test_counties_at_country_level():
+    """wkls.us.counties() returns counties in the US — no longer a 'must have region' error."""
+    count = wkls.us.counties().count()
+    assert count > 3000  # ~3,000 US counties
+
+
+def test_cities_at_country_level():
+    """wkls.us.cities() returns cities in the US."""
+    count = wkls.us.cities().count()
+    assert count > 10000
+
+
+def test_counties_at_region_level_unchanged():
+    """wkls.us.ca.counties() still works and returns CA counties."""
+    assert wkls.us.ca.counties().count() == 58  # California has 58 counties
+
+
+def test_counties_at_root_returns_all():
+    """wkls.counties() at root lists every county worldwide."""
+    assert wkls.counties().count() > 10000
+
+
+def test_cities_at_root_returns_all():
+    """wkls.cities() at root lists every city worldwide."""
+    assert wkls.cities().count() > 100000
+
+
+def test_no_region_country_counties_and_cities():
+    """Depth-1 list methods on no-region countries (FK) still work."""
+    assert wkls.fk.counties().count() >= 0
+    assert wkls.fk.cities().count() >= 1
+
+
 # ---------- Region-name resolution regression ----------
 
 

--- a/tests/test_us.py
+++ b/tests/test_us.py
@@ -12,13 +12,11 @@ def test_access():
     assert wkls.countries().count() == 219
     assert wkls.us.regions().count() == 51
     assert wkls.IN.regions().count() == 37
-    # Bracket access at the module root is no longer supported (PEP 562);
-    # use Wkl() or dot access. Chained bracket access still works.
-    assert wkls.IN["MH"].counties().count() == 36
-    assert wkls.IN["MH"].cities().count() == 346
+    assert wkls.india.maharashtra.counties().count() == 36
+    assert wkls.india.maharashtra.cities().count() == 346
 
     # Test San Francisco search returns DataFrame directly
-    san_francisco_results = wkls.us.ca["%San Francisco%"].to_arrow_table()
+    san_francisco_results = wkls.us.ca.search("San Francisco").to_arrow_table()
     assert san_francisco_results.num_rows == 2, (
         "San Francisco search should return exactly two results"
     )

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1303,28 +1303,34 @@ class Wkl:
         return sedona.sql(query)
 
     def search(self, query: str) -> sedonadb.dataframe.DataFrame:
-        """Search for locations matching a substring at the current chain level.
+        """Search for locations whose names contain a substring.
 
-        Performs a case-insensitive substring match against ``name_primary``
-        and ``name_en``. Returns a DataFrame — this is a discovery tool; read
-        the results, then use dot access to chain further.
+        Searches every row within the current chain's scope — countries,
+        dependencies, regions, counties, and localities alike — and returns
+        matches as a DataFrame. Rows carry a ``subtype`` column so callers
+        can tell what they got back.
+
+        The scope narrows with chain depth:
+
+        - ``wkls.search(q)``        — full dataset
+        - ``wkls.us.search(q)``     — everything under US
+        - ``wkls.us.ca.search(q)``  — everything under California
 
         Args:
-            query: Search string. Matched against the location name columns
-                with ``ILIKE '%query%'``.
+            query: Search string. Matched against ``name_primary`` and
+                ``name_en`` with ``ILIKE '%query%'``.
 
         Returns:
-            DataFrame with columns ``id, country, subtype, name_primary,
-            name_en`` (plus ``region`` at country and region levels).
+            DataFrame with ``id, country, region, subtype, name_primary, name_en``.
 
         Raises:
             ValueError: If called past city level (chain depth > 2).
 
         Examples:
             >>> import wkls
-            >>> wkls.search("united")           # countries with "united"
-            >>> wkls.us.search("new")           # US regions with "new"
-            >>> wkls.us.ca.search("san fran")   # CA cities with "san fran"
+            >>> wkls.search("san francisco")     # finds the city from root
+            >>> wkls.us.search("los angeles")    # scoped to US
+            >>> wkls.us.ca.search("san fran")    # scoped to California
         """
         depth = len(self.chain)
         if depth > 2:
@@ -1336,21 +1342,16 @@ class Wkl:
         escaped_query = sqlescape(query)
 
         if depth == 0:
-            sql = queries.SEARCH_COUNTRIES.format(query=escaped_query)
-        elif depth == 1:
-            sql = queries.SEARCH_REGIONS.format(
+            sql = queries.SEARCH_ROOT.format(query=escaped_query)
+        elif depth == 1 or not self._has_region:
+            # Depth 1, or depth 2 on a country that doesn't use regions.
+            sql = queries.SEARCH_COUNTRY.format(
                 country=sqlescape(self._country_iso), query=escaped_query
             )
-        else:  # depth == 2
-            if self._has_region:
-                sql = queries.SEARCH_CITIES.format(
-                    country=sqlescape(self._country_iso),
-                    region=sqlescape(self._region_iso),
-                    query=escaped_query,
-                )
-            else:
-                sql = queries.SEARCH_CITIES_NO_REGION.format(
-                    country=sqlescape(self._country_iso),
-                    query=escaped_query,
-                )
+        else:  # depth == 2 with regions
+            sql = queries.SEARCH_REGION.format(
+                country=sqlescape(self._country_iso),
+                region=sqlescape(self._region_iso),
+                query=escaped_query,
+            )
         return sedona.sql(sql)

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -192,6 +192,18 @@ sedona = _initialize_table()
 # process. Static per Overture version, safe to cache indefinitely.
 _country_info: dict[str, tuple[str, bool]] = {}
 
+# Cache for (country_iso, region_identifier) -> canonical region ISO.
+# The identifier key is lowercased raw input (ISO suffix like "mh", full
+# region ISO like "in-mh", or name like "maharashtra"). Canonical value
+# is the full region ISO ("IN-MH"). Static per Overture version.
+_region_info: dict[tuple[str, str], str] = {}
+
+# Cache for __dir__ results, keyed by chain tuple.
+# ()  -> root-level country identifiers
+# ("US",) -> US region identifiers
+# Values are sorted lists of ISO codes + normalized names.
+_dir_cache: dict[tuple[str, ...], list[str]] = {}
+
 
 def sqlescape(v: str) -> str:
     """Escape a string for safe SQL interpolation.
@@ -222,29 +234,66 @@ _WKL_DELEGATED_METHODS = frozenset(
         "counties",
         "cities",
         "subtypes",
+        "search",
     }
 )
 
+# Methods surfaced by __dir__ at each chain depth.
+_DIR_ROOT_METHODS = frozenset(
+    {
+        "Wkl",
+        "ChainableDataFrame",
+        "configure",
+        "countries",
+        "dependencies",
+        "overture_releases",
+        "overture_version",
+        "search",
+        "subtypes",
+    }
+)
+_DIR_COUNTRY_METHODS = frozenset(
+    {
+        "cities",
+        "counties",
+        "geojson",
+        "regions",
+        "search",
+        "wkb",
+        "wkt",
+    }
+)
+_DIR_REGION_METHODS = frozenset(
+    {
+        "cities",
+        "counties",
+        "geojson",
+        "search",
+        "wkb",
+        "wkt",
+    }
+)
+_DIR_CITY_METHODS = frozenset({"geojson", "wkb", "wkt"})
+
 
 def _build_error_hint(chain: list[str], suggestions: list[str]) -> str:
-    """Build error hint message with suggestions and wildcard tip.
+    """Build error hint message with suggestions and a search() tip.
 
     Args:
         chain: List of location identifiers in the chain.
         suggestions: List of suggested location names.
 
     Returns:
-        Formatted hint string with suggestions and wildcard search tip.
+        Formatted hint string with suggestions and a search() tip.
     """
     chain_str = ".".join(chain)
     failed_name = chain[-1]
     chain_prefix = ".".join(chain[:-1])
 
-    # Build wildcard example - handle root level specially
     if chain_prefix:
-        wildcard_example = f"wkls.{chain_prefix}['%{failed_name}%']"
+        search_example = f"wkls.{chain_prefix}.search('{failed_name}')"
     else:
-        wildcard_example = f"wkls['%{failed_name}%']"
+        search_example = f"wkls.search('{failed_name}')"
 
     if suggestions:
         suggestion_hint = f"Did you mean: {', '.join(suggestions)}?\n"
@@ -254,7 +303,7 @@ def _build_error_hint(chain: list[str], suggestions: list[str]) -> str:
     return (
         f"No results found for: {chain_str}\n"
         f"{suggestion_hint}"
-        f"Tip: Use {wildcard_example} to perform a wildcard search.\n"
+        f"Tip: Use {search_example} to search by name.\n"
     )
 
 
@@ -334,20 +383,33 @@ class ChainableDataFrame:
     def __getitem__(
         self, key: Any
     ) -> ChainableDataFrame | sedonadb.dataframe.DataFrame:
-        """Handle bracket access for location chaining or DataFrame indexing.
+        """[Deprecated] Bracket access for location chaining or DataFrame indexing.
 
-        Supports both DataFrame-style indexing and location chaining with
-        search patterns (using % wildcards).
-
-        Args:
-            key: Column name, list of columns, slice, or location string.
-
-        Returns:
-            ChainableDataFrame for location chaining, or DataFrame for indexing.
-
-        Raises:
-            ValueError: If chain exceeds maximum depth of 3.
+        See :meth:`Wkl.__getitem__` for migration guidance. DataFrame-style
+        indexing (list or slice keys) is not deprecated and does not warn.
         """
+        import warnings
+
+        # Location-style access (string key) — warn.
+        if isinstance(key, str):
+            if "%" in key:
+                cleaned = key.strip("%")
+                warnings.warn(
+                    "Bracket access with wildcards is deprecated; "
+                    f"use .search({cleaned!r}) instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            else:
+                chain_prefix = ".".join(self._chain) + "." if self._chain else ""
+                warnings.warn(
+                    "Bracket access is deprecated; "
+                    f"use dot access (wkls.{chain_prefix}{key.lower()}) or the "
+                    "corresponding name form.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
         # If we have a chain, continue chaining (location access mode)
         if self._chain:
             new_wkl = Wkl(self._chain + [key.lower()])
@@ -376,6 +438,10 @@ class ChainableDataFrame:
 
     def __arrow_c_array__(self, requested_schema=None):
         return Wkl(self._chain).__arrow_c_array__(requested_schema=requested_schema)
+
+    def __dir__(self) -> list[str]:
+        """Delegate to Wkl.__dir__ for chain-aware attribute listing."""
+        return Wkl(self._chain).__dir__()
 
     @property
     def _constructor(self) -> type[ChainableDataFrame]:
@@ -526,6 +592,43 @@ class Wkl:
         df_has = sedona.sql(queries.COUNTRY_HAS_REGIONS.format(country=sqlescape(iso)))
         return iso, df_has.count() > 0
 
+    @property
+    def _region_iso(self) -> str:
+        """Resolve ``self.chain[1]`` to its canonical region ISO (e.g. ``'IN-MH'``).
+
+        Lazy + cached. Handles both ISO suffixes (``'mh'`` or ``'IN-MH'``) and
+        region names (``'maharashtra'``). Returns an upper-cased naive form
+        like ``'IN-MAHARASHTRA'`` if no match is found so that downstream
+        queries return empty DataFrames and trigger the "Did you mean?" path.
+        """
+        raw = self.chain[1]
+        key = (self._country_iso, raw.lower())
+        if key not in _region_info:
+            _region_info[key] = self._lookup_region(raw)
+        return _region_info[key]
+
+    def _lookup_region(self, identifier: str) -> str:
+        """Resolve a region identifier to its canonical ISO (e.g. 'IN-MH').
+
+        Accepts bare suffix ('mh'), full ISO ('IN-MH'), or name ('maharashtra').
+        """
+        full_iso = (
+            identifier
+            if "-" in identifier
+            else f"{self._country_iso}-{identifier.upper()}"
+        )
+        df = sedona.sql(
+            queries.REGION_LOOKUP.format(
+                country=sqlescape(self._country_iso),
+                identifier=sqlescape(full_iso),
+                name=sqlescape(identifier),
+            )
+        )
+        table = df.to_arrow_table()
+        if table.num_rows == 0:
+            return full_iso.upper()
+        return table.column("iso")[0].as_py()
+
     def overture_version(self) -> str:
         """Return the version of the Overture Maps dataset being used.
 
@@ -607,6 +710,8 @@ class Wkl:
 
         _current_overture_version = overture_version
         _country_info.clear()
+        _region_info.clear()
+        _dir_cache.clear()
         sedona.read_parquet(
             _overture_uri(overture_version),
             options={
@@ -644,22 +749,96 @@ class Wkl:
             return ChainableDataFrame(df, new_wkl.chain)
         return new_wkl
 
+    def __dir__(self) -> list[str]:
+        """Return contextually valid attributes for the current chain level.
+
+        Includes both ISO codes and normalized names — both forms work via
+        ``__getattr__``, so both are advertised. Region-level and deeper
+        return methods only (cities are too numerous to list).
+        """
+        depth = len(self.chain)
+        if depth == 0:
+            methods: frozenset[str] = _DIR_ROOT_METHODS
+            locations = self._dir_countries()
+        elif depth == 1:
+            methods = _DIR_COUNTRY_METHODS
+            locations = self._dir_regions()
+        elif depth == 2:
+            methods = _DIR_REGION_METHODS
+            locations = []
+        else:
+            methods = _DIR_CITY_METHODS
+            locations = []
+        return sorted(set(methods) | set(locations))
+
+    def _dir_countries(self) -> list[str]:
+        """Return cached country-level dir entries (ISO codes + names)."""
+        key: tuple[str, ...] = ()
+        if key not in _dir_cache:
+            _dir_cache[key] = self._collect_dir_entries(
+                sedona.sql(queries.DIR_COUNTRIES)
+            )
+        return _dir_cache[key]
+
+    def _dir_regions(self) -> list[str]:
+        """Return cached region-level dir entries (ISO suffixes + names)."""
+        key: tuple[str, ...] = (self._country_iso,)
+        if key not in _dir_cache:
+            df = sedona.sql(
+                queries.DIR_REGIONS.format(country=sqlescape(self._country_iso))
+            )
+            _dir_cache[key] = self._collect_dir_entries(df)
+        return _dir_cache[key]
+
+    @staticmethod
+    def _collect_dir_entries(df: sedonadb.dataframe.DataFrame) -> list[str]:
+        """Collect ISO and name values from a dir() query result."""
+        table = df.to_arrow_table()
+        result: set[str] = set()
+        for i in range(table.num_rows):
+            iso = table.column("iso")[i].as_py()
+            name = table.column("name")[i].as_py()
+            if iso:
+                result.add(iso)
+            if name:
+                result.add(name)
+        return sorted(result)
+
     def __getitem__(
         self, key: str
     ) -> ChainableDataFrame | sedonadb.dataframe.DataFrame:
-        """Handle bracket access for location chaining.
+        """[Deprecated] Handle bracket access for location chaining.
 
-        Supports search patterns with % wildcards for fuzzy matching.
+        Emits a :class:`DeprecationWarning` pointing at the modern API:
 
-        Args:
-            key: Location identifier or search pattern.
+        - For name-based access, use dot notation: ``wkls.india`` instead of
+          ``wkls["IN"]``, ``wkls.us.oregon`` instead of ``wkls.us["OR"]``.
+        - For wildcard search, use :meth:`search`: ``wkls.us.ca.search("fran")``
+          instead of ``wkls.us.ca["%fran%"]``.
 
-        Returns:
-            ChainableDataFrame or DataFrame for search patterns.
-
-        Raises:
-            ValueError: If chain exceeds maximum depth of 3.
+        The old behavior is preserved for backward compatibility and will be
+        removed in a future major version.
         """
+        import warnings
+
+        if "%" in str(key):
+            cleaned = str(key).strip("%")
+            warnings.warn(
+                "Bracket access with wildcards is deprecated; "
+                f"use .search({cleaned!r}) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            chain_prefix = ".".join(self.chain) + "." if self.chain else ""
+            warnings.warn(
+                "Bracket access is deprecated; "
+                f"use dot access (wkls.{chain_prefix}{key.lower()}) or the "
+                "corresponding name form.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         new_wkl = Wkl(self.chain + [key.lower()])
         # Validate chain length immediately
         if len(new_wkl.chain) > 3 and "%" not in key:
@@ -718,8 +897,7 @@ class Wkl:
         if len(self.chain) > 2:
             query = queries.CITY
             params["country"] = country_iso
-            region_iso = country_iso + "-" + self.chain[1].upper()
-            params["region"] = region_iso
+            params["region"] = self._region_iso
             params["city"] = self.chain[2]
 
         return sedona.sql(query.format(**{k: sqlescape(v) for k, v in params.items()}))
@@ -777,10 +955,9 @@ class Wkl:
         else:
             # City-level with region (e.g., wkls.us.ca.sanfran)
             country_iso = self._country_iso
-            region = country_iso + "-" + self.chain[1].upper()
             query = queries.SUGGEST_CITY.format(
                 country=sqlescape(country_iso),
-                region_filter=f"AND region = '{sqlescape(region)}'",
+                region_filter=f"AND region = '{sqlescape(self._region_iso)}'",
                 search_term=sqlescape(search_term),
                 limit=n * 2,
             )
@@ -1068,7 +1245,6 @@ class Wkl:
             return sedona.sql(query.format(country=sqlescape(country_iso)))
 
         # len(self.chain) == 2
-        region_iso = country_iso + "-" + self.chain[1].upper()
         query = f"""
             SELECT * FROM wkls
             WHERE country = '{{country}}'
@@ -1076,7 +1252,9 @@ class Wkl:
               AND subtype IN {subtype_filter}
         """
         return sedona.sql(
-            query.format(country=sqlescape(country_iso), region=sqlescape(region_iso))
+            query.format(
+                country=sqlescape(country_iso), region=sqlescape(self._region_iso)
+            )
         )
 
     def counties(self) -> sedonadb.dataframe.DataFrame:
@@ -1123,3 +1301,56 @@ class Wkl:
 
         query = """SELECT DISTINCT subtype FROM wkls"""
         return sedona.sql(query)
+
+    def search(self, query: str) -> sedonadb.dataframe.DataFrame:
+        """Search for locations matching a substring at the current chain level.
+
+        Performs a case-insensitive substring match against ``name_primary``
+        and ``name_en``. Returns a DataFrame — this is a discovery tool; read
+        the results, then use dot access to chain further.
+
+        Args:
+            query: Search string. Matched against the location name columns
+                with ``ILIKE '%query%'``.
+
+        Returns:
+            DataFrame with columns ``id, country, subtype, name_primary,
+            name_en`` (plus ``region`` at country and region levels).
+
+        Raises:
+            ValueError: If called past city level (chain depth > 2).
+
+        Examples:
+            >>> import wkls
+            >>> wkls.search("united")           # countries with "united"
+            >>> wkls.us.search("new")           # US regions with "new"
+            >>> wkls.us.ca.search("san fran")   # CA cities with "san fran"
+        """
+        depth = len(self.chain)
+        if depth > 2:
+            raise ValueError(
+                "search() cannot be called past city level "
+                f"(chain has {depth} elements; max searchable depth is 2)."
+            )
+
+        escaped_query = sqlescape(query)
+
+        if depth == 0:
+            sql = queries.SEARCH_COUNTRIES.format(query=escaped_query)
+        elif depth == 1:
+            sql = queries.SEARCH_REGIONS.format(
+                country=sqlescape(self._country_iso), query=escaped_query
+            )
+        else:  # depth == 2
+            if self._has_region:
+                sql = queries.SEARCH_CITIES.format(
+                    country=sqlescape(self._country_iso),
+                    region=sqlescape(self._region_iso),
+                    query=escaped_query,
+                )
+            else:
+                sql = queries.SEARCH_CITIES_NO_REGION.format(
+                    country=sqlescape(self._country_iso),
+                    query=escaped_query,
+                )
+        return sedona.sql(sql)

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1176,75 +1176,58 @@ class Wkl:
         return sedona.sql(query)
 
     def regions(self) -> sedonadb.dataframe.DataFrame:
-        """Get regions for the current country.
+        """List regions in the current chain scope.
 
-        Must be called on a single-level chain (e.g., `wkls.us.regions()`).
+        Scope follows chain depth:
+            - ``wkls.regions()``     — every region worldwide
+            - ``wkls.us.regions()``  — every region in the US
 
         Returns:
-            DataFrame containing all region records for the country.
+            DataFrame of region rows.
 
         Raises:
-            ValueError: If called at wrong chain level or country has no regions.
+            ValueError: If called past country level (no regions below regions).
         """
-        if not self.chain or len(self.chain) > 1:
-            raise ValueError(
-                "regions() requires exactly one level of chaining. "
-                "Use wkls.<country>.regions() to get regions for a country."
-            )
+        return self._list_subtype("('region')", "regions")
 
-        country_iso = self._country_iso
-
-        if not self._has_region:
-            raise ValueError(
-                f"The country '{country_iso}' does not have regions in the dataset. "
-                f"Please directly call wkls['{country_iso.lower()}'].counties() or "
-                f"wkls['{country_iso.lower()}'].cities() to access its counties or cities."
-            )
-
-        query = """
-            SELECT * FROM wkls
-            WHERE country = '{country}'
-                AND subtype = 'region'
-        """
-        return sedona.sql(query.format(country=sqlescape(country_iso)))
-
-    def _get_subdivisions(
+    def _list_subtype(
         self, subtype_filter: str, method_name: str
     ) -> sedonadb.dataframe.DataFrame:
-        """Helper for counties() and cities() methods.
+        """List rows of the given subtype within the current chain scope.
 
         Args:
-            subtype_filter: SQL subtype filter (e.g., "'county'" or "('locality', 'localadmin')").
-            method_name: Name of the calling method for error messages.
+            subtype_filter: SQL subtype filter, e.g. ``"('county')"`` or
+                ``"('locality', 'localadmin')"``.
+            method_name: Calling method name for error messages.
 
         Returns:
-            DataFrame containing matching subdivision records.
+            DataFrame containing matching rows.
 
         Raises:
-            ValueError: If called at wrong chain level.
+            ValueError: If called past region level (chain depth > 2).
         """
-        if not self.chain or len(self.chain) > 2:
+        depth = len(self.chain)
+        if depth > 2:
             raise ValueError(
-                f"{method_name}() requires exactly one or two levels of chaining. "
-                f"Use wkls.<country>.<region>.{method_name}() to get {method_name} for a region."
+                f"{method_name}() cannot be called past region level "
+                f"(chain has {depth} elements; max list depth is 2)."
             )
 
-        country_iso = self._country_iso
+        if depth == 0:
+            query = f"SELECT * FROM wkls WHERE subtype IN {subtype_filter}"
+            return sedona.sql(query)
 
-        if len(self.chain) == 1:
-            if self._has_region:
-                raise ValueError(
-                    f"{method_name}() cannot be called on a country alone. "
-                    f"Use wkls.<country>.<region>.{method_name}() to get {method_name} for a region."
-                )
+        if depth == 1 or not self._has_region:
+            # Country-scoped: depth 1, or depth 2 on a no-region country
+            # (which addresses a specific city, so scope collapses to country).
             query = f"""
                 SELECT * FROM wkls
                 WHERE country = '{{country}}'
                   AND subtype IN {subtype_filter}
             """
-            return sedona.sql(query.format(country=sqlescape(country_iso)))
+            return sedona.sql(query.format(country=sqlescape(self._country_iso)))
 
-        # len(self.chain) == 2
+        # depth == 2 with regions: region-scoped
         query = f"""
             SELECT * FROM wkls
             WHERE country = '{{country}}'
@@ -1253,37 +1236,42 @@ class Wkl:
         """
         return sedona.sql(
             query.format(
-                country=sqlescape(country_iso), region=sqlescape(self._region_iso)
+                country=sqlescape(self._country_iso),
+                region=sqlescape(self._region_iso),
             )
         )
 
     def counties(self) -> sedonadb.dataframe.DataFrame:
-        """Get counties for the current region.
+        """List counties in the current chain scope.
 
-        Must be called on a two-level chain (e.g., `wkls.us.ca.counties()`),
-        or single-level for countries without regions.
+        Scope follows chain depth:
+            - ``wkls.counties()``         — every county worldwide
+            - ``wkls.us.counties()``      — every county in the US
+            - ``wkls.us.ca.counties()``   — every county in California
 
         Returns:
-            DataFrame containing all county records for the region.
+            DataFrame of county rows.
 
         Raises:
-            ValueError: If called at wrong chain level.
+            ValueError: If called past region level.
         """
-        return self._get_subdivisions("('county')", "counties")
+        return self._list_subtype("('county')", "counties")
 
     def cities(self) -> sedonadb.dataframe.DataFrame:
-        """Get cities for the current region.
+        """List cities (localities and localadmins) in the current chain scope.
 
-        Must be called on a two-level chain (e.g., `wkls.us.ca.cities()`),
-        or single-level for countries without regions.
+        Scope follows chain depth:
+            - ``wkls.cities()``         — every city worldwide
+            - ``wkls.us.cities()``      — every city in the US
+            - ``wkls.us.ca.cities()``   — every city in California
 
         Returns:
-            DataFrame containing all city records for the region.
+            DataFrame of city rows.
 
         Raises:
-            ValueError: If called at wrong chain level.
+            ValueError: If called past region level.
         """
-        return self._get_subdivisions("('locality', 'localadmin')", "cities")
+        return self._list_subtype("('locality', 'localadmin')", "cities")
 
     def subtypes(self) -> sedonadb.dataframe.DataFrame:
         """Get all distinct division subtypes in the dataset.

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -52,6 +52,19 @@ COUNTRY_HAS_REGIONS = """
       LIMIT 1
 """
 
+REGION_LOOKUP = """
+    SELECT DISTINCT region AS iso
+    FROM wkls
+    WHERE country = '{country}'
+      AND subtype = 'region'
+      AND (
+        region ILIKE '{identifier}'
+        OR REPLACE(name_en, ' ', '') ILIKE REPLACE('{name}', ' ', '')
+        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE('{name}', ' ', '')
+      )
+    LIMIT 1
+"""
+
 CITY = """
     SELECT * FROM wkls
     WHERE country ILIKE '{country}'
@@ -141,10 +154,82 @@ SUGGEST_REGION = """
     LIMIT {limit}
 """
 
-# Common expression for normalizing city names to chainable format
+# Common expression for normalizing names to chainable format.
+# Used by city-level suggestions, dir() queries, and search().
 _CHAINABLE_NAME_EXPR = (
     "LOWER(REGEXP_REPLACE(COALESCE(name_en, name_primary), '[^a-zA-Z0-9]', '', 'g'))"
 )
+
+# --- dir() queries (for Wkl.__dir__ introspection) ---
+
+# Root dir(): ISO codes and normalized names for countries and dependencies.
+DIR_COUNTRIES = f"""
+    SELECT DISTINCT
+      LOWER(country)          AS iso,
+      {_CHAINABLE_NAME_EXPR}  AS name
+    FROM wkls
+    WHERE subtype IN ('country', 'dependency')
+"""
+
+# Country-level dir(): ISO suffixes and normalized names for one country's regions.
+DIR_REGIONS = f"""
+    SELECT DISTINCT
+      LOWER(SPLIT_PART(region, '-', 2)) AS iso,
+      {_CHAINABLE_NAME_EXPR}            AS name
+    FROM wkls
+    WHERE country = '{{country}}'
+      AND subtype = 'region'
+"""
+
+# --- search() queries (case-insensitive substring match on location names) ---
+
+SEARCH_COUNTRIES = """
+    SELECT DISTINCT id, country, subtype, name_primary, name_en
+    FROM wkls
+    WHERE subtype IN ('country', 'dependency')
+      AND (
+        name_primary ILIKE '%{query}%'
+        OR name_en ILIKE '%{query}%'
+      )
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
+
+SEARCH_REGIONS = """
+    SELECT DISTINCT id, country, region, subtype, name_primary, name_en
+    FROM wkls
+    WHERE country = '{country}'
+      AND subtype = 'region'
+      AND (
+        name_primary ILIKE '%{query}%'
+        OR name_en ILIKE '%{query}%'
+      )
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
+
+SEARCH_CITIES = """
+    SELECT DISTINCT id, country, region, subtype, name_primary, name_en
+    FROM wkls
+    WHERE country = '{country}'
+      AND region = '{region}'
+      AND subtype IN ('county', 'locality', 'localadmin')
+      AND (
+        name_primary ILIKE '%{query}%'
+        OR name_en ILIKE '%{query}%'
+      )
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
+
+SEARCH_CITIES_NO_REGION = """
+    SELECT DISTINCT id, country, subtype, name_primary, name_en
+    FROM wkls
+    WHERE country = '{country}'
+      AND subtype IN ('county', 'locality', 'localadmin')
+      AND (
+        name_primary ILIKE '%{query}%'
+        OR name_en ILIKE '%{query}%'
+      )
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
 
 # For city-level suggestions (Levenshtein fuzzy matching)
 # Use {region_filter} = "AND region = '{region}'" or "" for countries without regions

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -181,24 +181,22 @@ DIR_REGIONS = f"""
       AND subtype = 'region'
 """
 
-# --- search() queries (case-insensitive substring match on location names) ---
+# --- search() queries ---
+# Each level scans all entities in its chain scope (any subtype), matching
+# the query substring against name_primary and name_en.
 
-SEARCH_COUNTRIES = """
-    SELECT DISTINCT id, country, subtype, name_primary, name_en
+SEARCH_ROOT = """
+    SELECT DISTINCT id, country, region, subtype, name_primary, name_en
     FROM wkls
-    WHERE subtype IN ('country', 'dependency')
-      AND (
-        name_primary ILIKE '%{query}%'
-        OR name_en ILIKE '%{query}%'
-      )
+    WHERE name_primary ILIKE '%{query}%'
+       OR name_en ILIKE '%{query}%'
     ORDER BY COALESCE(name_en, name_primary) ASC
 """
 
-SEARCH_REGIONS = """
+SEARCH_COUNTRY = """
     SELECT DISTINCT id, country, region, subtype, name_primary, name_en
     FROM wkls
     WHERE country = '{country}'
-      AND subtype = 'region'
       AND (
         name_primary ILIKE '%{query}%'
         OR name_en ILIKE '%{query}%'
@@ -206,24 +204,11 @@ SEARCH_REGIONS = """
     ORDER BY COALESCE(name_en, name_primary) ASC
 """
 
-SEARCH_CITIES = """
+SEARCH_REGION = """
     SELECT DISTINCT id, country, region, subtype, name_primary, name_en
     FROM wkls
     WHERE country = '{country}'
       AND region = '{region}'
-      AND subtype IN ('county', 'locality', 'localadmin')
-      AND (
-        name_primary ILIKE '%{query}%'
-        OR name_en ILIKE '%{query}%'
-      )
-    ORDER BY COALESCE(name_en, name_primary) ASC
-"""
-
-SEARCH_CITIES_NO_REGION = """
-    SELECT DISTINCT id, country, subtype, name_primary, name_en
-    FROM wkls
-    WHERE country = '{country}'
-      AND subtype IN ('county', 'locality', 'localadmin')
       AND (
         name_primary ILIKE '%{query}%'
         OR name_en ILIKE '%{query}%'


### PR DESCRIPTION
## Summary

Phase 2 of the usability work. Builds on the Phase 1 foundations (PEP 562, name-based resolution) with a consistent "scope to subtree" rule applied across three discovery surfaces.

- **`.search(query)`** on every chain level. Substring match against `name_primary` / `name_en`, returns a DataFrame with a `subtype` column. Scope narrows with depth — `wkls.search("san francisco")` scans globally, `wkls.us.search("san francisco")` scans within the US, `wkls.us.ca.search("san francisco")` scans within California.
- **`__dir__` overrides** on `Wkl` and `ChainableDataFrame`. Root and country levels advertise both ISO codes and English names (both forms resolve via `__getattr__`, both should be discoverable). Region level and deeper return methods only — cities are too numerous to list. Results are cached.
- **`.regions()`, `.counties()`, `.cities()` broaden to subtree scope** — same rule as `.search()`. `wkls.us.counties()` and `wkls.us.cities()` now work; the old "must have a region first" error is gone. `wkls.regions()` / `wkls.counties()` / `wkls.cities()` at root return every row globally. Depth-3 still raises.
- **`__getitem__` deprecated**, not removed. Bracket access (`wkls["IN"]`, `wkls.us.ca["%fran%"]`) still returns the same results but emits a `DeprecationWarning` pointing at dot access or `.search()`. Removal deferred to an eventual v2.0.
- **Error-hint migration.** Empty-result hints now read `wkls.us.ca.search('foo')` instead of `wkls.us.ca['%foo%']`.
- **Latent Phase 1 bug fixed.** `wkls.india.maharashtra.counties()` previously returned 0 because region-level methods built the region filter as `IN-MAHARASHTRA` instead of `IN-MH`. Added a lazy `_region_iso` property backed by a module-level `_region_info` cache, mirroring the existing `_country_info` pattern.
- **README updated** to reflect the new `.search()` method, subtree-scoped listings, `dir()` discovery, and the bracket deprecation.

## Breaking changes

None intentional at the v1.x level. `__getitem__` still works, just warns.

Two previously-raised errors are now "return empty" instead:
- `wkls.fk.regions()` → empty DataFrame (was: `ValueError("does not have regions")`)
- `wkls.us.counties()`, `wkls.us.cities()` → populated DataFrames (were: `ValueError("cannot be called on a country alone")`)

Both changes are strict improvements for callers.

## Test plan

- [x] 85 tests pass + 2 documented xfails (diacritic limitations)
- [x] `ruff format --check` and `ruff check` pass
- [x] `wkls.search("san francisco")` returns 147+ rows worldwide, including US San Francisco
- [x] `wkls.us.search("los angeles")` returns the city, county, and suburb matches
- [x] `dir(wkls)` contains both `"us"` and `"unitedstates"`
- [x] `dir(wkls.us)` contains both `"ca"` and `"california"`
- [x] `dir(wkls.us.ca)` returns methods only
- [x] `wkls.us.counties()` returns 3000+ counties (previously raised)
- [x] `wkls.india.maharashtra.counties()` matches `wkls.IN.MH.counties()`
- [x] `Wkl()["IN"]` still works and emits a `DeprecationWarning`