### PR TITLE
fix: resolve region names in counties/cities chain methods

### DIFF
--- a/tests/test_llm_usability.py
+++ b/tests/test_llm_usability.py
@@ -171,3 +171,27 @@ def test_cache_query_count(cold_caches, capsys):
         "SELECT * FROM wkls\n    WHERE country = 'US'\n      AND subtype = 'region'"
         not in second_out
     )
+
+
+# ---------- Region-name resolution regression ----------
+
+
+def test_counties_via_name_chain():
+    """wkls.india.maharashtra.counties() should match the ISO-chain result.
+
+    Regression: pre-fix, name-based chains built region filters as
+    'IN-MAHARASHTRA' (concatenating country_iso + chain[1].upper()),
+    which matched zero rows. Must equal the ISO-chain path.
+    """
+    from_name = wkls.india.maharashtra.counties().count()
+    from_iso = wkls.IN.MH.counties().count()
+    assert from_name == from_iso
+    assert from_name >= 1
+
+
+def test_cities_via_name_chain():
+    """Name-based chain also supports cities() symmetrically with ISO."""
+    from_name = wkls.india.maharashtra.cities().count()
+    from_iso = wkls.IN.MH.cities().count()
+    assert from_name == from_iso
+    assert from_name >= 1

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -192,6 +192,12 @@ sedona = _initialize_table()
 # process. Static per Overture version, safe to cache indefinitely.
 _country_info: dict[str, tuple[str, bool]] = {}
 
+# Cache for (country_iso, region_identifier) -> canonical region ISO.
+# The identifier key is lowercased raw input (ISO suffix like "mh",
+# full region ISO like "in-mh", or name like "maharashtra").
+# Canonical value is the full region ISO ("IN-MH").
+_region_info: dict[tuple[str, str], str] = {}
+
 
 def sqlescape(v: str) -> str:
     """Escape a string for safe SQL interpolation.
@@ -526,6 +532,43 @@ class Wkl:
         df_has = sedona.sql(queries.COUNTRY_HAS_REGIONS.format(country=sqlescape(iso)))
         return iso, df_has.count() > 0
 
+    @property
+    def _region_iso(self) -> str:
+        """Resolve ``self.chain[1]`` to its canonical region ISO (e.g. ``'IN-MH'``).
+
+        Lazy + cached. Handles both ISO suffixes (``'mh'`` or ``'IN-MH'``)
+        and region names (``'maharashtra'``). Returns an upper-cased naive
+        form (``'IN-MAHARASHTRA'``) if no match is found so downstream
+        queries return empty DataFrames and trigger the "Did you mean?" path.
+        """
+        raw = self.chain[1]
+        key = (self._country_iso, raw.lower())
+        if key not in _region_info:
+            _region_info[key] = self._lookup_region(raw)
+        return _region_info[key]
+
+    def _lookup_region(self, identifier: str) -> str:
+        """Resolve a region identifier to its canonical ISO (e.g. 'IN-MH').
+
+        Accepts bare suffix ('mh'), full ISO ('IN-MH'), or name ('maharashtra').
+        """
+        full_iso = (
+            identifier
+            if "-" in identifier
+            else f"{self._country_iso}-{identifier.upper()}"
+        )
+        df = sedona.sql(
+            queries.REGION_LOOKUP.format(
+                country=sqlescape(self._country_iso),
+                identifier=sqlescape(full_iso),
+                name=sqlescape(identifier),
+            )
+        )
+        table = df.to_arrow_table()
+        if table.num_rows == 0:
+            return full_iso.upper()
+        return table.column("iso")[0].as_py()
+
     def overture_version(self) -> str:
         """Return the version of the Overture Maps dataset being used.
 
@@ -607,6 +650,7 @@ class Wkl:
 
         _current_overture_version = overture_version
         _country_info.clear()
+        _region_info.clear()
         sedona.read_parquet(
             _overture_uri(overture_version),
             options={
@@ -718,8 +762,7 @@ class Wkl:
         if len(self.chain) > 2:
             query = queries.CITY
             params["country"] = country_iso
-            region_iso = country_iso + "-" + self.chain[1].upper()
-            params["region"] = region_iso
+            params["region"] = self._region_iso
             params["city"] = self.chain[2]
 
         return sedona.sql(query.format(**{k: sqlescape(v) for k, v in params.items()}))
@@ -777,10 +820,9 @@ class Wkl:
         else:
             # City-level with region (e.g., wkls.us.ca.sanfran)
             country_iso = self._country_iso
-            region = country_iso + "-" + self.chain[1].upper()
             query = queries.SUGGEST_CITY.format(
                 country=sqlescape(country_iso),
-                region_filter=f"AND region = '{sqlescape(region)}'",
+                region_filter=f"AND region = '{sqlescape(self._region_iso)}'",
                 search_term=sqlescape(search_term),
                 limit=n * 2,
             )
@@ -1068,7 +1110,6 @@ class Wkl:
             return sedona.sql(query.format(country=sqlescape(country_iso)))
 
         # len(self.chain) == 2
-        region_iso = country_iso + "-" + self.chain[1].upper()
         query = f"""
             SELECT * FROM wkls
             WHERE country = '{{country}}'
@@ -1076,7 +1117,9 @@ class Wkl:
               AND subtype IN {subtype_filter}
         """
         return sedona.sql(
-            query.format(country=sqlescape(country_iso), region=sqlescape(region_iso))
+            query.format(
+                country=sqlescape(country_iso), region=sqlescape(self._region_iso)
+            )
         )
 
     def counties(self) -> sedonadb.dataframe.DataFrame:

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -52,6 +52,19 @@ COUNTRY_HAS_REGIONS = """
       LIMIT 1
 """
 
+REGION_LOOKUP = """
+    SELECT DISTINCT region AS iso
+    FROM wkls
+    WHERE country = '{country}'
+      AND subtype = 'region'
+      AND (
+        region ILIKE '{identifier}'
+        OR REPLACE(name_en, ' ', '') ILIKE REPLACE('{name}', ' ', '')
+        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE('{name}', ' ', '')
+      )
+    LIMIT 1
+"""
+
 CITY = """
     SELECT * FROM wkls
     WHERE country ILIKE '{country}'


### PR DESCRIPTION
## Summary

Fixes a latent bug from the Phase 1 name-resolution work. `wkls.india.maharashtra.counties()` returned 0 rows because region-level methods built their region filter as `country_iso + \"-\" + chain[1].upper()`, producing `IN-MAHARASHTRA` instead of `IN-MH`. The dataset holds region ISOs like `IN-MH`, so the filter matched nothing.

## Root cause

Three call sites concatenated the country ISO with the uppercased chain element to form a region filter:
- `Wkl.resolve()` at chain depth 3
- `Wkl._get_suggestions()` city branch
- `Wkl._get_subdivisions()` depth-2 branch

All three assumed `chain[1]` was the region ISO suffix. After Phase 1, `chain[1]` can be a name (\"maharashtra\"), which breaks the concatenation.

## Fix

- New `REGION_LOOKUP` query (ISO-or-name match, same pattern as `COUNTRY_LOOKUP`).
- New module-level `_region_info` cache keyed by `(country_iso, raw_identifier_lower)` → canonical region ISO.
- Lazy `Wkl._region_iso` property that populates the cache on first access.
- Three call sites route through `self._region_iso` instead of inline concatenation.
- `Wkl.configure()` clears `_region_info` alongside `_country_info`.

## Test plan

- [x] 58 tests pass + 2 xfails (unchanged)
- [x] Two regression tests added: `test_counties_via_name_chain`, `test_cities_via_name_chain`, both assert the name-chain count equals the ISO-chain count
- [x] ruff format + check pass

## Follow-ups (separate PRs, stacked on this one)

- PR adding `.search()`, `__dir__` overrides, `__getitem__` deprecation
- PR broadening `.search()` and listing methods to subtree scope