### PR TITLE
feat: add .search(), __dir__ discovery, deprecate bracket access

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest fixtures shared across the test suite."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+
+@pytest.fixture
+def ignore_bracket_deprecation():
+    """Silence DeprecationWarning emitted by legacy __getitem__ calls.
+
+    Used by tests that exercise bracket access on purpose — for example,
+    regression tests asserting the shim still works, or older tests that
+    predate the `.search()` / name-access migration.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Bracket access.*deprecated",
+            category=DeprecationWarning,
+        )
+        yield

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -137,7 +137,7 @@ def test_nonexistent_location_errors():
         pass  # Could be various exceptions depending on validation
 
     # Nonexistent city with search pattern (this should return empty results)
-    result = wkls.us.ca["%nonexistentcity%"]
+    result = wkls.us.ca.search("nonexistentcity")
     assert result.count() == 0, "Nonexistent city search should return empty DataFrame"
 
 
@@ -180,8 +180,8 @@ def test_did_you_mean_country_level():
     assert "No results found for: u" in repr_str
     assert "Did you mean:" in repr_str
     assert "us" in repr_str
-    # Verify wildcard tip has correct syntax for root level
-    assert "wkls['%u%']" in repr_str
+    # Verify search tip has correct syntax for root level
+    assert "wkls.search('u')" in repr_str
 
 
 def test_suggestions_for_extended_codes():
@@ -203,7 +203,7 @@ def test_no_suggestions_for_unrelated_codes():
     # No suggestions since no code starts with "xyz" and "xyz" doesn't start with any code
     assert "Did you mean:" not in repr_str
     # But wildcard tip is still shown
-    assert "wkls.us['%xyz%']" in repr_str
+    assert "wkls.us.search('xyz')" in repr_str
 
 
 def test_did_you_mean_partial_match():
@@ -269,14 +269,14 @@ def test_suggestions_in_repr():
     assert "No results found for: us.ca.sanfran" in repr_str
     assert "Did you mean:" in repr_str
     assert "sanfrancisco" in repr_str
-    assert "wkls.us.ca['%sanfran%']" in repr_str
+    assert "wkls.us.ca.search('sanfran')" in repr_str
 
 
-def test_suggestions_in_repr_bracket_access():
+def test_suggestions_in_repr_bracket_access(ignore_bracket_deprecation):
     """Test that suggestions appear when using bracket access."""
     # Access a non-existent country using bracket syntax on a Wkl instance.
-    # The module itself is no longer subscriptable (PEP 562 compliant); use
-    # Wkl() for bracket access if needed.
+    # Bracket access is deprecated but must still work as a shim — that's
+    # exactly what this test guards against regressing.
     from wkls import Wkl
 
     result = Wkl()["uss"]
@@ -284,7 +284,7 @@ def test_suggestions_in_repr_bracket_access():
     assert "No results found for: uss" in repr_str
     assert "Did you mean:" in repr_str
     assert "us" in repr_str
-    assert "wkls['%uss%']" in repr_str
+    assert "wkls.search('uss')" in repr_str
 
 
 def test_chainable_dataframe_error_propagation():

--- a/tests/test_llm_usability.py
+++ b/tests/test_llm_usability.py
@@ -1,13 +1,15 @@
-"""Golden tests for Phase 1 LLM/agent usability work.
+"""Golden tests for LLM/agent usability work.
 
-Covers PEP 562 dual import, name-based country/region resolution and
-the _country_info cache, and docstring smoke coverage.
+Covers PEP 562 dual import, name-based country/region resolution,
+the _country_info cache, docstring smoke coverage, __dir__ overrides,
+.search(), and deprecation of bracket access.
 """
 
 from __future__ import annotations
 
 import os
 import types
+import warnings
 
 import pytest
 
@@ -195,3 +197,145 @@ def test_cities_via_name_chain():
     from_iso = wkls.IN.MH.cities().count()
     assert from_name == from_iso
     assert from_name >= 1
+
+
+# ---------- Stream 3: __dir__ overrides ----------
+
+
+def test_dir_root_both_forms():
+    """dir(wkls) exposes both ISO codes and names for countries."""
+    entries = dir(wkls)
+    assert "us" in entries
+    assert "unitedstates" in entries
+    assert "in" in entries
+    assert "india" in entries
+    assert "Wkl" in entries
+
+
+def test_dir_country_level_both_forms():
+    """dir(wkls.us) exposes both region ISO suffixes and region names."""
+    entries = dir(wkls.us)
+    assert "ca" in entries
+    assert "california" in entries
+    assert "or" in entries
+    assert "oregon" in entries
+    assert "regions" in entries
+
+
+def test_dir_region_level_methods_only():
+    """dir(wkls.us.ca) returns methods only — no city identifiers."""
+    entries = dir(wkls.us.ca)
+    assert set(entries) == {"cities", "counties", "geojson", "search", "wkb", "wkt"}
+
+
+def test_dir_city_level_geometry_methods_only():
+    """dir on a resolved city returns geometry-output methods."""
+    entries = dir(wkls.us.ca.sanfrancisco)
+    assert set(entries) == {"geojson", "wkb", "wkt"}
+
+
+def test_dir_cached_no_query_on_repeat(capsys):
+    """Second dir() call at the same level fires zero SQL queries."""
+    core._dir_cache.clear()
+    os.environ["WKLS_DEBUG"] = "true"
+    try:
+        dir(wkls)
+        first_out = capsys.readouterr().out
+        dir(wkls)
+        second_out = capsys.readouterr().out
+    finally:
+        del os.environ["WKLS_DEBUG"]
+
+    assert "subtype IN ('country', 'dependency')" in first_out
+    assert "SELECT DISTINCT" not in second_out
+
+
+# ---------- Stream 2: .search() (narrow scope) ----------
+
+
+def test_search_root_returns_countries():
+    """wkls.search() at root returns matching countries/dependencies."""
+    df = wkls.search("united")
+    assert df.count() >= 3  # US, UK, UAE, at minimum
+
+
+def test_search_country_returns_regions():
+    """search() at country level returns matching regions."""
+    df = wkls.us.search("new")
+    table = df.to_arrow_table()
+    names = {table.column("name_primary")[i].as_py() for i in range(table.num_rows)}
+    assert {"New Hampshire", "New Jersey", "New Mexico", "New York"}.issubset(names)
+
+
+def test_search_region_returns_cities():
+    """search() at region level returns matching cities/counties."""
+    df = wkls.us.ca.search("san fran")
+    assert df.count() >= 1
+    table = df.to_arrow_table()
+    names = [table.column("name_primary")[i].as_py() for i in range(table.num_rows)]
+    assert any("San Francisco" in n for n in names)
+
+
+def test_search_no_region_country():
+    """search() works on countries without regions (e.g., FK)."""
+    df = wkls.fk.search("stanley")
+    assert df is not None
+
+
+def test_search_too_deep_raises():
+    """search() past city level raises ValueError."""
+    with pytest.raises(ValueError, match="past city level"):
+        wkls.us.ca.sanfrancisco.search("foo")
+
+
+# ---------- __getitem__ deprecation ----------
+
+
+def test_bracket_access_emits_deprecation():
+    """Wkl()[...] still works but emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="Bracket access is deprecated"):
+        result = Wkl()["IN"]
+    assert result._df.to_arrow_table().column("country")[0].as_py() == "IN"
+
+
+def test_bracket_wildcard_emits_deprecation_pointing_to_search():
+    """Wildcard bracket access warns and suggests .search()."""
+    with pytest.warns(
+        DeprecationWarning, match=r"wildcards is deprecated; use \.search\('fran'\)"
+    ):
+        result = wkls.us.ca["%fran%"]
+    assert result.count() >= 1
+
+
+def test_chainable_bracket_emits_deprecation():
+    """ChainableDataFrame[...] also warns."""
+    with pytest.warns(DeprecationWarning, match="Bracket access is deprecated"):
+        wkls.us["CA"]
+
+
+def test_chainable_list_index_does_not_warn():
+    """DataFrame-style list indexing on ChainableDataFrame does NOT emit the warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        try:
+            wkls.us.ca[["id", "country"]]
+        except DeprecationWarning:
+            pytest.fail("DataFrame-style indexing should not emit DeprecationWarning")
+        except Exception:
+            pass
+
+
+# ---------- Error-hint migration ----------
+
+
+def test_error_hint_uses_search_not_brackets():
+    """Empty-result hint points at .search(), not bracket wildcards."""
+    repr_str = repr(wkls.us.ca.nonexistentcity)
+    assert "wkls.us.ca.search('nonexistentcity')" in repr_str
+    assert "['%" not in repr_str
+
+
+def test_error_hint_at_root_uses_search():
+    """Root-level empty result hints at wkls.search()."""
+    repr_str = repr(wkls.zz)
+    assert "wkls.search('zz')" in repr_str

--- a/tests/test_us.py
+++ b/tests/test_us.py
@@ -12,13 +12,11 @@ def test_access():
     assert wkls.countries().count() == 219
     assert wkls.us.regions().count() == 51
     assert wkls.IN.regions().count() == 37
-    # Bracket access at the module root is no longer supported (PEP 562);
-    # use Wkl() or dot access. Chained bracket access still works.
-    assert wkls.IN["MH"].counties().count() == 36
-    assert wkls.IN["MH"].cities().count() == 346
+    assert wkls.india.maharashtra.counties().count() == 36
+    assert wkls.india.maharashtra.cities().count() == 346
 
     # Test San Francisco search returns DataFrame directly
-    san_francisco_results = wkls.us.ca["%San Francisco%"].to_arrow_table()
+    san_francisco_results = wkls.us.ca.search("San Francisco").to_arrow_table()
     assert san_francisco_results.num_rows == 2, (
         "San Francisco search should return exactly two results"
     )

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -198,6 +198,12 @@ _country_info: dict[str, tuple[str, bool]] = {}
 # Canonical value is the full region ISO ("IN-MH").
 _region_info: dict[tuple[str, str], str] = {}
 
+# Cache for __dir__ results, keyed by chain tuple.
+# ()  -> root-level country identifiers
+# ("US",) -> US region identifiers
+# Values are sorted lists of ISO codes + normalized names.
+_dir_cache: dict[tuple[str, ...], list[str]] = {}
+
 
 def sqlescape(v: str) -> str:
     """Escape a string for safe SQL interpolation.
@@ -228,29 +234,58 @@ _WKL_DELEGATED_METHODS = frozenset(
         "counties",
         "cities",
         "subtypes",
+        "search",
     }
 )
 
+# Methods surfaced by __dir__ at each chain depth.
+_DIR_ROOT_METHODS = frozenset(
+    {
+        "Wkl",
+        "ChainableDataFrame",
+        "configure",
+        "countries",
+        "dependencies",
+        "overture_releases",
+        "overture_version",
+        "search",
+        "subtypes",
+    }
+)
+_DIR_COUNTRY_METHODS = frozenset(
+    {
+        "cities",
+        "counties",
+        "geojson",
+        "regions",
+        "search",
+        "wkb",
+        "wkt",
+    }
+)
+_DIR_REGION_METHODS = frozenset(
+    {
+        "cities",
+        "counties",
+        "geojson",
+        "search",
+        "wkb",
+        "wkt",
+    }
+)
+_DIR_CITY_METHODS = frozenset({"geojson", "wkb", "wkt"})
+
 
 def _build_error_hint(chain: list[str], suggestions: list[str]) -> str:
-    """Build error hint message with suggestions and wildcard tip.
-
-    Args:
-        chain: List of location identifiers in the chain.
-        suggestions: List of suggested location names.
-
-    Returns:
-        Formatted hint string with suggestions and wildcard search tip.
-    """
+    """Build error hint message with suggestions and a search() tip."""
     chain_str = ".".join(chain)
     failed_name = chain[-1]
     chain_prefix = ".".join(chain[:-1])
 
-    # Build wildcard example - handle root level specially
     if chain_prefix:
-        wildcard_example = f"wkls.{chain_prefix}['%{failed_name}%']"
+        search_example = f"wkls.{chain_prefix}.search('{failed_name}')"
     else:
-        wildcard_example = f"wkls['%{failed_name}%']"
+        search_example = f"wkls.search('{failed_name}')"
 
     if suggestions:
         suggestion_hint = f"Did you mean: {', '.join(suggestions)}?\n"
@@ -260,7 +295,7 @@ def _build_error_hint(chain: list[str], suggestions: list[str]) -> str:
     return (
         f"No results found for: {chain_str}\n"
         f"{suggestion_hint}"
-        f"Tip: Use {wildcard_example} to perform a wildcard search.\n"
+        f"Tip: Use {search_example} to search by name.\n"
     )
 
 
@@ -340,20 +375,32 @@ class ChainableDataFrame:
     def __getitem__(
         self, key: Any
     ) -> ChainableDataFrame | sedonadb.dataframe.DataFrame:
-        """Handle bracket access for location chaining or DataFrame indexing.
+        """[Deprecated] Bracket access for location chaining or DataFrame indexing.
 
-        Supports both DataFrame-style indexing and location chaining with
-        search patterns (using % wildcards).
-
-        Args:
-            key: Column name, list of columns, slice, or location string.
-
-        Returns:
-            ChainableDataFrame for location chaining, or DataFrame for indexing.
-
-        Raises:
-            ValueError: If chain exceeds maximum depth of 3.
+        See :meth:`Wkl.__getitem__` for migration guidance. DataFrame-style
+        indexing (list or slice keys) is not deprecated and does not warn.
         """
+        import warnings
+
+        if isinstance(key, str):
+            if "%" in key:
+                cleaned = key.strip("%")
+                warnings.warn(
+                    "Bracket access with wildcards is deprecated; "
+                    f"use .search({cleaned!r}) instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            else:
+                chain_prefix = ".".join(self._chain) + "." if self._chain else ""
+                warnings.warn(
+                    "Bracket access is deprecated; "
+                    f"use dot access (wkls.{chain_prefix}{key.lower()}) or the "
+                    "corresponding name form.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
         # If we have a chain, continue chaining (location access mode)
         if self._chain:
             new_wkl = Wkl(self._chain + [key.lower()])
@@ -382,6 +429,10 @@ class ChainableDataFrame:
 
     def __arrow_c_array__(self, requested_schema=None):
         return Wkl(self._chain).__arrow_c_array__(requested_schema=requested_schema)
+
+    def __dir__(self) -> list[str]:
+        """Delegate to Wkl.__dir__ for chain-aware attribute listing."""
+        return Wkl(self._chain).__dir__()
 
     @property
     def _constructor(self) -> type[ChainableDataFrame]:
@@ -651,6 +702,7 @@ class Wkl:
         _current_overture_version = overture_version
         _country_info.clear()
         _region_info.clear()
+        _dir_cache.clear()
         sedona.read_parquet(
             _overture_uri(overture_version),
             options={
@@ -688,22 +740,96 @@ class Wkl:
             return ChainableDataFrame(df, new_wkl.chain)
         return new_wkl
 
+    def __dir__(self) -> list[str]:
+        """Return contextually valid attributes for the current chain level.
+
+        Includes both ISO codes and normalized names — both forms work via
+        ``__getattr__``, so both are advertised. Region-level and deeper
+        return methods only (cities are too numerous to list).
+        """
+        depth = len(self.chain)
+        if depth == 0:
+            methods: frozenset[str] = _DIR_ROOT_METHODS
+            locations = self._dir_countries()
+        elif depth == 1:
+            methods = _DIR_COUNTRY_METHODS
+            locations = self._dir_regions()
+        elif depth == 2:
+            methods = _DIR_REGION_METHODS
+            locations = []
+        else:
+            methods = _DIR_CITY_METHODS
+            locations = []
+        return sorted(set(methods) | set(locations))
+
+    def _dir_countries(self) -> list[str]:
+        """Return cached country-level dir entries (ISO codes + names)."""
+        key: tuple[str, ...] = ()
+        if key not in _dir_cache:
+            _dir_cache[key] = self._collect_dir_entries(
+                sedona.sql(queries.DIR_COUNTRIES)
+            )
+        return _dir_cache[key]
+
+    def _dir_regions(self) -> list[str]:
+        """Return cached region-level dir entries (ISO suffixes + names)."""
+        key: tuple[str, ...] = (self._country_iso,)
+        if key not in _dir_cache:
+            df = sedona.sql(
+                queries.DIR_REGIONS.format(country=sqlescape(self._country_iso))
+            )
+            _dir_cache[key] = self._collect_dir_entries(df)
+        return _dir_cache[key]
+
+    @staticmethod
+    def _collect_dir_entries(df: sedonadb.dataframe.DataFrame) -> list[str]:
+        """Collect ISO and name values from a dir() query result."""
+        table = df.to_arrow_table()
+        result: set[str] = set()
+        for i in range(table.num_rows):
+            iso = table.column("iso")[i].as_py()
+            name = table.column("name")[i].as_py()
+            if iso:
+                result.add(iso)
+            if name:
+                result.add(name)
+        return sorted(result)
+
     def __getitem__(
         self, key: str
     ) -> ChainableDataFrame | sedonadb.dataframe.DataFrame:
-        """Handle bracket access for location chaining.
+        """[Deprecated] Handle bracket access for location chaining.
 
-        Supports search patterns with % wildcards for fuzzy matching.
+        Emits a :class:`DeprecationWarning` pointing at the modern API:
 
-        Args:
-            key: Location identifier or search pattern.
+        - For name-based access, use dot notation: ``wkls.india`` instead of
+          ``wkls["IN"]``, ``wkls.us.oregon`` instead of ``wkls.us["OR"]``.
+        - For wildcard search, use :meth:`search`: ``wkls.us.ca.search("fran")``
+          instead of ``wkls.us.ca["%fran%"]``.
 
-        Returns:
-            ChainableDataFrame or DataFrame for search patterns.
-
-        Raises:
-            ValueError: If chain exceeds maximum depth of 3.
+        The old behavior is preserved for backward compatibility and will be
+        removed in a future major version.
         """
+        import warnings
+
+        if "%" in str(key):
+            cleaned = str(key).strip("%")
+            warnings.warn(
+                "Bracket access with wildcards is deprecated; "
+                f"use .search({cleaned!r}) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            chain_prefix = ".".join(self.chain) + "." if self.chain else ""
+            warnings.warn(
+                "Bracket access is deprecated; "
+                f"use dot access (wkls.{chain_prefix}{key.lower()}) or the "
+                "corresponding name form.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         new_wkl = Wkl(self.chain + [key.lower()])
         # Validate chain length immediately
         if len(new_wkl.chain) > 3 and "%" not in key:
@@ -1166,3 +1292,56 @@ class Wkl:
 
         query = """SELECT DISTINCT subtype FROM wkls"""
         return sedona.sql(query)
+
+    def search(self, query: str) -> sedonadb.dataframe.DataFrame:
+        """Search for locations matching a substring at the current chain level.
+
+        Performs a case-insensitive substring match against ``name_primary``
+        and ``name_en``. Returns a DataFrame — this is a discovery tool;
+        read the results, then use dot access to chain further.
+
+        Args:
+            query: Search string. Matched against the location name columns
+                with ``ILIKE '%query%'``.
+
+        Returns:
+            DataFrame with ``id, country, subtype, name_primary, name_en``
+            (plus ``region`` at country and region levels).
+
+        Raises:
+            ValueError: If called past city level (chain depth > 2).
+
+        Examples:
+            >>> import wkls
+            >>> wkls.search("united")           # countries with "united"
+            >>> wkls.us.search("new")           # US regions with "new"
+            >>> wkls.us.ca.search("san fran")   # CA cities with "san fran"
+        """
+        depth = len(self.chain)
+        if depth > 2:
+            raise ValueError(
+                "search() cannot be called past city level "
+                f"(chain has {depth} elements; max searchable depth is 2)."
+            )
+
+        escaped_query = sqlescape(query)
+
+        if depth == 0:
+            sql = queries.SEARCH_COUNTRIES.format(query=escaped_query)
+        elif depth == 1:
+            sql = queries.SEARCH_REGIONS.format(
+                country=sqlescape(self._country_iso), query=escaped_query
+            )
+        else:  # depth == 2
+            if self._has_region:
+                sql = queries.SEARCH_CITIES.format(
+                    country=sqlescape(self._country_iso),
+                    region=sqlescape(self._region_iso),
+                    query=escaped_query,
+                )
+            else:
+                sql = queries.SEARCH_CITIES_NO_REGION.format(
+                    country=sqlescape(self._country_iso),
+                    query=escaped_query,
+                )
+        return sedona.sql(sql)

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -154,10 +154,83 @@ SUGGEST_REGION = """
     LIMIT {limit}
 """
 
-# Common expression for normalizing city names to chainable format
+# Common expression for normalizing names to chainable format.
+# Used by city-level suggestions, dir() queries, and search().
 _CHAINABLE_NAME_EXPR = (
     "LOWER(REGEXP_REPLACE(COALESCE(name_en, name_primary), '[^a-zA-Z0-9]', '', 'g'))"
 )
+
+# --- dir() queries (for Wkl.__dir__ introspection) ---
+
+# Root dir(): ISO codes and normalized names for countries and dependencies.
+DIR_COUNTRIES = f"""
+    SELECT DISTINCT
+      LOWER(country)          AS iso,
+      {_CHAINABLE_NAME_EXPR}  AS name
+    FROM wkls
+    WHERE subtype IN ('country', 'dependency')
+"""
+
+# Country-level dir(): ISO suffixes and normalized names for one country's regions.
+DIR_REGIONS = f"""
+    SELECT DISTINCT
+      LOWER(SPLIT_PART(region, '-', 2)) AS iso,
+      {_CHAINABLE_NAME_EXPR}            AS name
+    FROM wkls
+    WHERE country = '{{country}}'
+      AND subtype = 'region'
+"""
+
+# --- search() queries ---
+# Each level matches against name_primary and name_en within its chain scope.
+
+SEARCH_COUNTRIES = """
+    SELECT DISTINCT id, country, subtype, name_primary, name_en
+    FROM wkls
+    WHERE subtype IN ('country', 'dependency')
+      AND (
+        name_primary ILIKE '%{query}%'
+        OR name_en ILIKE '%{query}%'
+      )
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
+
+SEARCH_REGIONS = """
+    SELECT DISTINCT id, country, region, subtype, name_primary, name_en
+    FROM wkls
+    WHERE country = '{country}'
+      AND subtype = 'region'
+      AND (
+        name_primary ILIKE '%{query}%'
+        OR name_en ILIKE '%{query}%'
+      )
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
+
+SEARCH_CITIES = """
+    SELECT DISTINCT id, country, region, subtype, name_primary, name_en
+    FROM wkls
+    WHERE country = '{country}'
+      AND region = '{region}'
+      AND subtype IN ('county', 'locality', 'localadmin')
+      AND (
+        name_primary ILIKE '%{query}%'
+        OR name_en ILIKE '%{query}%'
+      )
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
+
+SEARCH_CITIES_NO_REGION = """
+    SELECT DISTINCT id, country, subtype, name_primary, name_en
+    FROM wkls
+    WHERE country = '{country}'
+      AND subtype IN ('county', 'locality', 'localadmin')
+      AND (
+        name_primary ILIKE '%{query}%'
+        OR name_en ILIKE '%{query}%'
+      )
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
 
 # For city-level suggestions (Levenshtein fuzzy matching)
 # Use {region_filter} = "AND region = '{region}'" or "" for countries without regions


### PR DESCRIPTION
> Stacked on #47. Target branch is \`pranav/bugfix/region-name-resolution\` — will retarget to main once #47 merges.

## Summary

Three related changes that together replace bracket access as the primary discovery surface:

- **`__dir__` overrides** on \`Wkl\` and \`ChainableDataFrame\`. Root and country levels advertise both ISO codes and English names — both forms work via \`__getattr__\`, both should be discoverable via \`dir()\`. Region level returns methods only (cities are too numerous to list). Results are cached.

- **\`.search(query)\`** on every chain level. Substring match against \`name_primary\` / \`name_en\` at the level matching the current chain depth:
  - \`wkls.search("united")\` → countries/dependencies
  - \`wkls.us.search("new")\` → regions of the US
  - \`wkls.us.ca.search("san fran")\` → cities/counties in CA

- **\`__getitem__\` deprecated.** Bracket access (\`wkls["IN"]\`, \`wkls.us.ca["%fran%"]\`) still returns the same results but emits a \`DeprecationWarning\` pointing at dot access or \`.search()\`. Removal deferred to an eventual v2.0.

Error-hint text migrates: empty-result \`repr\` now suggests \`wkls.us.ca.search('foo')\` instead of \`wkls.us.ca['%foo%']\`. Two existing tests migrate bracket calls to the modern API; one uses a new \`ignore_bracket_deprecation\` fixture to exercise the shim without noisy warnings.

## Breaking changes

None at v1.x. Bracket access still works, just warns.

## Test plan

- [x] 74 tests pass + 2 xfails (diacritic limitations, unchanged)
- [x] \`ruff format --check\` and \`ruff check\` pass
- [x] 16 new tests in \`tests/test_llm_usability.py\` cover the full feature surface
- [x] \`Wkl()["IN"]\` still works and emits a DeprecationWarning
- [x] \`dir(wkls)\` contains both \`"us"\` and \`"unitedstates"\`
- [x] \`wkls.us.ca.search("san fran")\` returns a San Francisco row

## Follow-up

- PR stacked on this one will broaden \`.search()\` and \`.regions()\`/\`.counties()\`/\`.cities()\` to subtree scope.