### PR TITLE
feat: subtree-scoped .search() and list methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ wkls.us.ca.sanfrancisco.wkt()
 # "MULTIPOLYGON (((-122.5279985 37.8155806...)))"
 ```
 
-- Chainable attribute access to countries, states, counties, and cities
+- Chainable attribute access by ISO code *or* English name (`wkls.us.ca.sanfrancisco`, `wkls.india.maharashtra`)
+- `.search("query")` at any chain level — scoped to the current subtree
 - Precise geometries from [Overture Maps Foundation](https://overturemaps.org/) — no bounding boxes, no shapefiles
 - Outputs boundaries in WKT, WKB, or GeoJSON
 - Support for HexWKB and SVG planned
@@ -69,22 +70,40 @@ wkls.de.geojson()  # GeoJSON string
 
 ### Exploring the dataset
 
+Listing methods scope to the current chain, all the way up to the dataset root:
+
 ```python
 wkls.countries()       # all countries
 wkls.dependencies()    # all dependencies
+wkls.regions()         # every region worldwide
+wkls.counties()        # every county worldwide
+wkls.cities()          # every city worldwide
+
 wkls.us.regions()      # regions in the US
+wkls.us.counties()     # every county in the US
+wkls.us.cities()       # every city in the US
+
 wkls.us.ca.counties()  # counties in California
 wkls.us.ca.cities()    # cities in California
-wkls.fk.cities()       # countries without regions work too
 ```
 
-### Wildcard search
+`dir(wkls)` and `dir(wkls.us)` list every attribute that resolves at that
+level — both ISO codes and English names — for interactive exploration
+and tab completion.
 
-Use `%` for pattern matching when you're not sure of the exact name:
+### Search
+
+`.search(query)` finds every row whose name contains the query substring.
+Scope narrows with chain depth:
 
 ```python
-wkls.us.ca["%francis%"]  # matches "San Francisco"
+wkls.search("san francisco")        # anywhere in the dataset
+wkls.us.search("san francisco")     # anywhere in the US
+wkls.us.ca.search("san francisco")  # anywhere in California
 ```
+
+Results come back as a DataFrame with a `subtype` column, so callers can
+filter countries from cities easily.
 
 ### Pinning an Overture version
 
@@ -105,19 +124,18 @@ export WKLS_OVERTURE_VERSION=2025-12-17.0
 
 Priority: `configure()` > environment variable > auto-detect.
 
-### Bracket access
+### Bracket access (deprecated)
 
-Most keyword/numeric collisions are resolved by name access (`wkls.austria.burgenland`
-instead of `wkls.at["1"]`). Bracket syntax is still available on chained objects for
-the rare cases where attribute access collides with a DataFrame method:
+Bracket access (`wkls.us["ne"]`, `wkls.us.ca["%fran%"]`) still works but
+emits a `DeprecationWarning` pointing at the modern replacement:
 
-```python
-wkls.us["ne"].wkt()     # Nebraska (wkls.us.ne would call DataFrame.ne)
-wkls.us.ca["%fran%"]    # wildcard search
-```
+- Keyword / numeric collisions → use the English name:
+  `wkls.us.nebraska`, `wkls.austria.burgenland`.
+- Wildcard search → use `.search()`:
+  `wkls.us.ca.search("fran")`.
 
-Bracket access at the module root (`wkls["..."]`) is not supported — real Python
-modules aren't subscriptable. Use dot access or `Wkl()["..."]` instead.
+Bracket access at the module root (`wkls["..."]`) is not supported — real
+Python modules aren't subscriptable. Use dot access or `Wkl()["..."]`.
 
 ## How it works
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,11 +4,10 @@ import wkls
 
 
 def test_countries_without_region():
-    with pytest.raises(ValueError) as exc_info:
-        wkls.fk.regions()
-    assert "The country 'FK' does not have regions in the dataset" in str(
-        exc_info.value
-    )
+    """Countries with no regions return an empty DataFrame, not an error."""
+    # Regions now scope to a subtree; countries like FK that have no region
+    # rows simply return zero — no longer a special error case.
+    assert wkls.fk.regions().count() == 0
 
 
 def test_empty_chain_error():
@@ -40,65 +39,32 @@ def test_countries_chaining_error():
     assert "wkls.countries()" in str(exc_info.value)
 
 
-def test_regions_chaining_errors():
-    """Test regions() validation errors."""
-    # regions() on root should fail
+def test_regions_at_region_level_returns_self():
+    """regions() at region level returns the region itself — the only region row in that scope."""
+    df = wkls.us.ca.regions().to_arrow_table()
+    assert df.num_rows == 1
+    assert df.column("region")[0].as_py() == "US-CA"
+
+
+def test_regions_past_region_level_raises():
+    """regions() past region level raises (depth 3 has no subtree)."""
     with pytest.raises(ValueError) as exc_info:
-        wkls.regions()
-    assert "regions() requires exactly one level of chaining" in str(exc_info.value)
-    assert "wkls.<country>.regions()" in str(exc_info.value)
-
-    # regions() on country.region should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.us.ca.regions()
-    assert "regions() requires exactly one level of chaining" in str(exc_info.value)
+        wkls.us.ca.sanfrancisco.regions()
+    assert "past region level" in str(exc_info.value)
 
 
-def test_counties_chaining_errors():
-    """Test counties() validation errors."""
-    # counties() on root should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.counties()
-    assert "counties() requires exactly one or two levels of chaining" in str(
-        exc_info.value
-    )
-    assert "wkls.<country>.<region>.counties()" in str(exc_info.value)
-
-    # counties() on country only should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.us.counties()
-    assert "counties() cannot be called on a country alone" in str(exc_info.value)
-    assert "wkls.<country>.<region>.counties()" in str(exc_info.value)
-
-    # counties() on country.region.city should fail
+def test_counties_past_region_level_raises():
+    """counties() past region level raises (depth 3 has no subtree)."""
     with pytest.raises(ValueError) as exc_info:
         wkls.us.ca.sanfrancisco.counties()
-    assert "counties() requires exactly one or two levels of chaining" in str(
-        exc_info.value
-    )
+    assert "past region level" in str(exc_info.value)
 
 
-def test_cities_chaining_errors():
-    """Test cities() validation errors."""
-    # cities() on root should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.cities()
-    assert "cities() requires exactly one or two levels of chaining" in str(
-        exc_info.value
-    )
-    assert "wkls.<country>.<region>.cities()" in str(exc_info.value)
-
-    # cities() on country only should fail
-    with pytest.raises(ValueError) as exc_info:
-        wkls.us.cities()
-    assert "cities() cannot be called on a country alone" in str(exc_info.value)
-
-    # cities() on country.region.city should fail
+def test_cities_past_region_level_raises():
+    """cities() past region level raises (depth 3 has no subtree)."""
     with pytest.raises(ValueError) as exc_info:
         wkls.us.ca.sanfrancisco.cities()
-    assert "cities() requires exactly one or two levels of chaining" in str(
-        exc_info.value
-    )
+    assert "past region level" in str(exc_info.value)
 
 
 def test_subtypes_chaining_error():
@@ -297,11 +263,9 @@ def test_chainable_dataframe_error_propagation():
         us_data.countries()
     assert "countries() can only be called on the root object" in str(exc_info.value)
 
-    # regions() should fail on chained data (more than 1 level)
+    # regions() on a region-level chain returns the region itself.
     ca_data = wkls.us.ca
-    with pytest.raises(ValueError) as exc_info:
-        ca_data.regions()
-    assert "regions() requires exactly one level of chaining" in str(exc_info.value)
+    assert ca_data.regions().count() == 1
 
 
 def test_version_attribute():
@@ -323,9 +287,10 @@ def test_dunder_attributes_raise_attribute_error():
 if __name__ == "__main__":
     test_empty_chain_error()
     test_countries_chaining_error()
-    test_regions_chaining_errors()
-    test_counties_chaining_errors()
-    test_cities_chaining_errors()
+    test_regions_at_region_level_returns_self()
+    test_regions_past_region_level_raises()
+    test_counties_past_region_level_raises()
+    test_cities_past_region_level_raises()
     test_subtypes_chaining_error()
     test_too_many_chained_attributes()
     test_nonexistent_location_errors()

--- a/tests/test_llm_usability.py
+++ b/tests/test_llm_usability.py
@@ -250,21 +250,48 @@ def test_dir_cached_no_query_on_repeat(capsys):
     assert "SELECT DISTINCT" not in second_out
 
 
-# ---------- Stream 2: .search() (narrow scope) ----------
+# ---------- Stream 2: .search() (subtree scope) ----------
 
 
-def test_search_root_returns_countries():
-    """wkls.search() at root returns matching countries/dependencies."""
-    df = wkls.search("united")
-    assert df.count() >= 3  # US, UK, UAE, at minimum
+def test_search_root_returns_mixed_subtypes():
+    """wkls.search() at root scans every subtype, not just countries."""
+    df = wkls.search("san francisco").to_arrow_table()
+    subtypes = {df.column("subtype")[i].as_py() for i in range(df.num_rows)}
+    # No country named San Francisco but many cities/counties;
+    # the result should include city-like subtypes.
+    assert subtypes & {"locality", "localadmin", "county"}, (
+        f"Expected city-like subtypes, got {subtypes}"
+    )
 
 
-def test_search_country_returns_regions():
-    """search() at country level returns matching regions."""
-    df = wkls.us.search("new")
-    table = df.to_arrow_table()
-    names = {table.column("name_primary")[i].as_py() for i in range(table.num_rows)}
-    assert {"New Hampshire", "New Jersey", "New Mexico", "New York"}.issubset(names)
+def test_search_finds_city_from_root():
+    """A root-level search for a city name returns the actual city."""
+    df = wkls.search("san francisco").to_arrow_table()
+    matches = [
+        (df.column("country")[i].as_py(), df.column("name_primary")[i].as_py())
+        for i in range(df.num_rows)
+    ]
+    assert ("US", "San Francisco") in matches
+
+
+def test_search_country_scope_expands():
+    """search() under a country now finds cities, not just regions."""
+    df = wkls.us.search("los angeles").to_arrow_table()
+    subtypes = {df.column("subtype")[i].as_py() for i in range(df.num_rows)}
+    assert subtypes & {"locality", "county"}
+
+
+def test_search_country_finds_regions_too():
+    """Country-level search still returns region matches alongside cities."""
+    df = wkls.us.search("new").to_arrow_table()
+    names_by_subtype = {
+        (df.column("subtype")[i].as_py(), df.column("name_primary")[i].as_py())
+        for i in range(df.num_rows)
+    }
+    region_names = {n for st, n in names_by_subtype if st == "region"}
+    assert {"New Hampshire", "New Jersey", "New Mexico", "New York"}.issubset(
+        region_names
+    )
 
 
 def test_search_region_returns_cities():
@@ -277,7 +304,7 @@ def test_search_region_returns_cities():
 
 
 def test_search_no_region_country():
-    """search() works on countries without regions (e.g., FK)."""
+    """search() on countries without regions scopes to that country."""
     df = wkls.fk.search("stanley")
     assert df is not None
 
@@ -286,6 +313,51 @@ def test_search_too_deep_raises():
     """search() past city level raises ValueError."""
     with pytest.raises(ValueError, match="past city level"):
         wkls.us.ca.sanfrancisco.search("foo")
+
+
+# ---------- List methods: subtree-scoped regions/counties/cities ----------
+
+
+def test_regions_at_root_returns_all():
+    """wkls.regions() at root returns every region worldwide."""
+    # ~3,900 regions in the dataset; generous lower bound for release drift.
+    assert wkls.regions().count() > 3000
+
+
+def test_regions_scoped_to_country():
+    """wkls.us.regions() returns regions scoped to that country."""
+    assert wkls.us.regions().count() == 51  # 50 states + DC
+
+
+def test_counties_at_country_level():
+    """wkls.us.counties() returns counties in the US — no longer raises."""
+    assert wkls.us.counties().count() > 3000
+
+
+def test_cities_at_country_level():
+    """wkls.us.cities() returns cities in the US."""
+    assert wkls.us.cities().count() > 10000
+
+
+def test_counties_at_region_level_unchanged():
+    """wkls.us.ca.counties() still returns CA counties."""
+    assert wkls.us.ca.counties().count() == 58
+
+
+def test_counties_at_root_returns_all():
+    """wkls.counties() at root lists every county worldwide."""
+    assert wkls.counties().count() > 10000
+
+
+def test_cities_at_root_returns_all():
+    """wkls.cities() at root lists every city worldwide."""
+    assert wkls.cities().count() > 100000
+
+
+def test_no_region_country_counties_and_cities():
+    """Depth-1 list methods on no-region countries (FK) still work."""
+    assert wkls.fk.counties().count() >= 0
+    assert wkls.fk.cities().count() >= 1
 
 
 # ---------- __getitem__ deprecation ----------

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1167,75 +1167,58 @@ class Wkl:
         return sedona.sql(query)
 
     def regions(self) -> sedonadb.dataframe.DataFrame:
-        """Get regions for the current country.
+        """List regions in the current chain scope.
 
-        Must be called on a single-level chain (e.g., `wkls.us.regions()`).
+        Scope follows chain depth:
+            - ``wkls.regions()``     — every region worldwide
+            - ``wkls.us.regions()``  — every region in the US
 
         Returns:
-            DataFrame containing all region records for the country.
+            DataFrame of region rows.
 
         Raises:
-            ValueError: If called at wrong chain level or country has no regions.
+            ValueError: If called past region level (no regions below regions).
         """
-        if not self.chain or len(self.chain) > 1:
-            raise ValueError(
-                "regions() requires exactly one level of chaining. "
-                "Use wkls.<country>.regions() to get regions for a country."
-            )
+        return self._list_subtype("('region')", "regions")
 
-        country_iso = self._country_iso
-
-        if not self._has_region:
-            raise ValueError(
-                f"The country '{country_iso}' does not have regions in the dataset. "
-                f"Please directly call wkls['{country_iso.lower()}'].counties() or "
-                f"wkls['{country_iso.lower()}'].cities() to access its counties or cities."
-            )
-
-        query = """
-            SELECT * FROM wkls
-            WHERE country = '{country}'
-                AND subtype = 'region'
-        """
-        return sedona.sql(query.format(country=sqlescape(country_iso)))
-
-    def _get_subdivisions(
+    def _list_subtype(
         self, subtype_filter: str, method_name: str
     ) -> sedonadb.dataframe.DataFrame:
-        """Helper for counties() and cities() methods.
+        """List rows of the given subtype within the current chain scope.
 
         Args:
-            subtype_filter: SQL subtype filter (e.g., "'county'" or "('locality', 'localadmin')").
-            method_name: Name of the calling method for error messages.
+            subtype_filter: SQL subtype filter, e.g. ``"('county')"`` or
+                ``"('locality', 'localadmin')"``.
+            method_name: Calling method name for error messages.
 
         Returns:
-            DataFrame containing matching subdivision records.
+            DataFrame containing matching rows.
 
         Raises:
-            ValueError: If called at wrong chain level.
+            ValueError: If called past region level (chain depth > 2).
         """
-        if not self.chain or len(self.chain) > 2:
+        depth = len(self.chain)
+        if depth > 2:
             raise ValueError(
-                f"{method_name}() requires exactly one or two levels of chaining. "
-                f"Use wkls.<country>.<region>.{method_name}() to get {method_name} for a region."
+                f"{method_name}() cannot be called past region level "
+                f"(chain has {depth} elements; max list depth is 2)."
             )
 
-        country_iso = self._country_iso
+        if depth == 0:
+            query = f"SELECT * FROM wkls WHERE subtype IN {subtype_filter}"
+            return sedona.sql(query)
 
-        if len(self.chain) == 1:
-            if self._has_region:
-                raise ValueError(
-                    f"{method_name}() cannot be called on a country alone. "
-                    f"Use wkls.<country>.<region>.{method_name}() to get {method_name} for a region."
-                )
+        if depth == 1 or not self._has_region:
+            # Country-scoped: depth 1, or depth 2 on a no-region country
+            # (which addresses a specific city, so scope collapses to country).
             query = f"""
                 SELECT * FROM wkls
                 WHERE country = '{{country}}'
                   AND subtype IN {subtype_filter}
             """
-            return sedona.sql(query.format(country=sqlescape(country_iso)))
+            return sedona.sql(query.format(country=sqlescape(self._country_iso)))
 
-        # len(self.chain) == 2
+        # depth == 2 with regions: region-scoped
         query = f"""
             SELECT * FROM wkls
             WHERE country = '{{country}}'
@@ -1244,37 +1227,42 @@ class Wkl:
         """
         return sedona.sql(
             query.format(
-                country=sqlescape(country_iso), region=sqlescape(self._region_iso)
+                country=sqlescape(self._country_iso),
+                region=sqlescape(self._region_iso),
             )
         )
 
     def counties(self) -> sedonadb.dataframe.DataFrame:
-        """Get counties for the current region.
+        """List counties in the current chain scope.
 
-        Must be called on a two-level chain (e.g., `wkls.us.ca.counties()`),
-        or single-level for countries without regions.
+        Scope follows chain depth:
+            - ``wkls.counties()``         — every county worldwide
+            - ``wkls.us.counties()``      — every county in the US
+            - ``wkls.us.ca.counties()``   — every county in California
 
         Returns:
-            DataFrame containing all county records for the region.
+            DataFrame of county rows.
 
         Raises:
-            ValueError: If called at wrong chain level.
+            ValueError: If called past region level.
         """
-        return self._get_subdivisions("('county')", "counties")
+        return self._list_subtype("('county')", "counties")
 
     def cities(self) -> sedonadb.dataframe.DataFrame:
-        """Get cities for the current region.
+        """List cities (localities and localadmins) in the current chain scope.
 
-        Must be called on a two-level chain (e.g., `wkls.us.ca.cities()`),
-        or single-level for countries without regions.
+        Scope follows chain depth:
+            - ``wkls.cities()``         — every city worldwide
+            - ``wkls.us.cities()``      — every city in the US
+            - ``wkls.us.ca.cities()``   — every city in California
 
         Returns:
-            DataFrame containing all city records for the region.
+            DataFrame of city rows.
 
         Raises:
-            ValueError: If called at wrong chain level.
+            ValueError: If called past region level.
         """
-        return self._get_subdivisions("('locality', 'localadmin')", "cities")
+        return self._list_subtype("('locality', 'localadmin')", "cities")
 
     def subtypes(self) -> sedonadb.dataframe.DataFrame:
         """Get all distinct division subtypes in the dataset.
@@ -1294,28 +1282,34 @@ class Wkl:
         return sedona.sql(query)
 
     def search(self, query: str) -> sedonadb.dataframe.DataFrame:
-        """Search for locations matching a substring at the current chain level.
+        """Search for locations whose names contain a substring.
 
-        Performs a case-insensitive substring match against ``name_primary``
-        and ``name_en``. Returns a DataFrame — this is a discovery tool;
-        read the results, then use dot access to chain further.
+        Searches every row within the current chain's scope — countries,
+        dependencies, regions, counties, and localities alike — and returns
+        matches as a DataFrame. Rows carry a ``subtype`` column so callers
+        can tell what they got back.
+
+        The scope narrows with chain depth:
+
+        - ``wkls.search(q)``        — full dataset
+        - ``wkls.us.search(q)``     — everything under US
+        - ``wkls.us.ca.search(q)``  — everything under California
 
         Args:
-            query: Search string. Matched against the location name columns
-                with ``ILIKE '%query%'``.
+            query: Search string. Matched against ``name_primary`` and
+                ``name_en`` with ``ILIKE '%query%'``.
 
         Returns:
-            DataFrame with ``id, country, subtype, name_primary, name_en``
-            (plus ``region`` at country and region levels).
+            DataFrame with ``id, country, region, subtype, name_primary, name_en``.
 
         Raises:
             ValueError: If called past city level (chain depth > 2).
 
         Examples:
             >>> import wkls
-            >>> wkls.search("united")           # countries with "united"
-            >>> wkls.us.search("new")           # US regions with "new"
-            >>> wkls.us.ca.search("san fran")   # CA cities with "san fran"
+            >>> wkls.search("san francisco")     # finds the city from root
+            >>> wkls.us.search("los angeles")    # scoped to US
+            >>> wkls.us.ca.search("san fran")    # scoped to California
         """
         depth = len(self.chain)
         if depth > 2:
@@ -1327,21 +1321,16 @@ class Wkl:
         escaped_query = sqlescape(query)
 
         if depth == 0:
-            sql = queries.SEARCH_COUNTRIES.format(query=escaped_query)
-        elif depth == 1:
-            sql = queries.SEARCH_REGIONS.format(
+            sql = queries.SEARCH_ROOT.format(query=escaped_query)
+        elif depth == 1 or not self._has_region:
+            # Depth 1, or depth 2 on a country that doesn't use regions.
+            sql = queries.SEARCH_COUNTRY.format(
                 country=sqlescape(self._country_iso), query=escaped_query
             )
-        else:  # depth == 2
-            if self._has_region:
-                sql = queries.SEARCH_CITIES.format(
-                    country=sqlescape(self._country_iso),
-                    region=sqlescape(self._region_iso),
-                    query=escaped_query,
-                )
-            else:
-                sql = queries.SEARCH_CITIES_NO_REGION.format(
-                    country=sqlescape(self._country_iso),
-                    query=escaped_query,
-                )
+        else:  # depth == 2 with regions
+            sql = queries.SEARCH_REGION.format(
+                country=sqlescape(self._country_iso),
+                region=sqlescape(self._region_iso),
+                query=escaped_query,
+            )
         return sedona.sql(sql)

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -182,24 +182,21 @@ DIR_REGIONS = f"""
 """
 
 # --- search() queries ---
-# Each level matches against name_primary and name_en within its chain scope.
+# Each level scans all entities in its chain scope (any subtype), matching
+# the query substring against name_primary and name_en.
 
-SEARCH_COUNTRIES = """
-    SELECT DISTINCT id, country, subtype, name_primary, name_en
+SEARCH_ROOT = """
+    SELECT DISTINCT id, country, region, subtype, name_primary, name_en
     FROM wkls
-    WHERE subtype IN ('country', 'dependency')
-      AND (
-        name_primary ILIKE '%{query}%'
-        OR name_en ILIKE '%{query}%'
-      )
+    WHERE name_primary ILIKE '%{query}%'
+       OR name_en ILIKE '%{query}%'
     ORDER BY COALESCE(name_en, name_primary) ASC
 """
 
-SEARCH_REGIONS = """
+SEARCH_COUNTRY = """
     SELECT DISTINCT id, country, region, subtype, name_primary, name_en
     FROM wkls
     WHERE country = '{country}'
-      AND subtype = 'region'
       AND (
         name_primary ILIKE '%{query}%'
         OR name_en ILIKE '%{query}%'
@@ -207,24 +204,11 @@ SEARCH_REGIONS = """
     ORDER BY COALESCE(name_en, name_primary) ASC
 """
 
-SEARCH_CITIES = """
+SEARCH_REGION = """
     SELECT DISTINCT id, country, region, subtype, name_primary, name_en
     FROM wkls
     WHERE country = '{country}'
       AND region = '{region}'
-      AND subtype IN ('county', 'locality', 'localadmin')
-      AND (
-        name_primary ILIKE '%{query}%'
-        OR name_en ILIKE '%{query}%'
-      )
-    ORDER BY COALESCE(name_en, name_primary) ASC
-"""
-
-SEARCH_CITIES_NO_REGION = """
-    SELECT DISTINCT id, country, subtype, name_primary, name_en
-    FROM wkls
-    WHERE country = '{country}'
-      AND subtype IN ('county', 'locality', 'localadmin')
       AND (
         name_primary ILIKE '%{query}%'
         OR name_en ILIKE '%{query}%'


### PR DESCRIPTION
> Stacked on #48 (which is stacked on #47). Target branch is \`pranav/feature/search-dir-deprecation\` — will retarget to main once the parents merge.

## Summary

One rule across every discovery method: each call scopes to the current chain's subtree, without special-casing which subtypes to return.

| Call | Before | After |
|---|---|---|
| \`wkls.search(q)\` | countries only | full metadata table (any subtype) |
| \`wkls.us.search(q)\` | regions only | everything under US |
| \`wkls.us.ca.search(q)\` | cities only | cities/counties under CA (unchanged) |
| \`wkls.regions()\` | *(no such method at root)* | every region worldwide |
| \`wkls.counties()\` | *(no such method at root)* | every county worldwide |
| \`wkls.cities()\` | *(no such method at root)* | every city worldwide |
| \`wkls.us.counties()\` | **raises** | every county in the US |
| \`wkls.us.cities()\` | **raises** | every city in the US |
| \`wkls.us.ca.counties()\` | CA counties | unchanged |

Past region level still raises — nothing below a specific city to list. Depth-2 on a no-region country (FK) collapses to country scope.

## Behavior changes

Two previously-raised errors now return populated DataFrames:

- \`wkls.fk.regions()\` → empty DataFrame (was: \`ValueError(\"does not have regions\")\`)
- \`wkls.us.counties()\`, \`wkls.us.cities()\` → populated DataFrames (were: \`ValueError(\"cannot be called on a country alone\")\`)

Both are strict improvements for callers.

## Implementation

- \`queries.py\`: collapse four narrow \`SEARCH_*\` queries into three broader ones (\`SEARCH_ROOT\`, \`SEARCH_COUNTRY\`, \`SEARCH_REGION\`).
- \`core.py\`: simplify \`.search()\`; rename \`_get_subdivisions\` → \`_list_subtype\` as a general helper; broaden \`regions()/counties()/cities()\`.
- README refresh: new search section, expanded \"Exploring the dataset\", bracket-access section renamed to \"(deprecated)\" with the modern replacements called out.

## Test plan

- [x] 85 tests pass + 2 xfails (diacritic limitations, unchanged)
- [x] ruff format + check pass
- [x] \`wkls.search(\"san francisco\")\` returns ≥100 rows worldwide including US San Francisco
- [x] \`wkls.us.counties()\` returns 3000+ rows (previously raised)
- [x] \`wkls.us.ca.counties()\` still returns 58 (unchanged)
- [x] \`wkls.fk.regions()\` returns empty DataFrame (was: ValueError)