### PR TITLE
fix: lazy-load the remote Overture view to keep import offline-safe

### DIFF
--- a/tests/test_lazy_overture.py
+++ b/tests/test_lazy_overture.py
@@ -1,0 +1,112 @@
+"""Tests for lazy-loading the remote Overture GeoParquet view.
+
+``import wkls`` must succeed without network access. All chain
+resolution, search, listing, and introspection methods run against
+the bundled local metadata. Only geometry methods (``.wkt()``,
+``.wkb()``, ``.geojson()``) reach S3, and they do so lazily on first
+call.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+import pytest
+
+import wkls
+from wkls import core
+
+
+def test_import_without_network_subprocess():
+    """A fresh import in a subprocess with S3 blocked still succeeds.
+
+    Runs in a subprocess with a module-level monkeypatch that replaces
+    ``urllib.request.urlopen`` before ``import wkls`` fires, then
+    exercises the offline-safe surfaces. This is the strongest form
+    of the guarantee — no shared state with the parent process.
+    """
+    script = r"""
+import urllib.request, urllib.error
+urllib.request.urlopen = lambda *a, **kw: (_ for _ in ()).throw(
+    urllib.error.URLError("blocked for offline-import test")
+)
+
+import wkls  # must not raise
+
+assert wkls.countries().count() > 0, "countries() should work offline"
+assert wkls.us.regions().count() > 0, "regions() should work offline"
+assert wkls.us.ca.sanfrancisco._df.count() == 1, "chain resolution should work offline"
+assert wkls.us.ca.search('oakland').count() >= 1, "search should work offline"
+print("OK")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert result.stdout.strip().endswith("OK")
+
+
+def test_ensure_overture_loaded_is_idempotent(monkeypatch):
+    """Calling ``_ensure_overture_loaded`` twice only registers once."""
+    # Reset the module flag so we can observe the first load.
+    monkeypatch.setattr(core, "_overture_view_loaded", False)
+
+    calls = {"read_parquet": 0}
+    original_read_parquet = core.sedona.read_parquet
+
+    def counting_read_parquet(*args, **kwargs):
+        calls["read_parquet"] += 1
+        return original_read_parquet(*args, **kwargs)
+
+    monkeypatch.setattr(core.sedona, "read_parquet", counting_read_parquet)
+
+    core._ensure_overture_loaded()
+    first = calls["read_parquet"]
+    core._ensure_overture_loaded()
+    second = calls["read_parquet"]
+
+    assert first == 1, "first call should register the view"
+    assert second == first, "second call should short-circuit"
+    assert core._overture_view_loaded is True
+
+
+def test_geometry_triggers_overture_load(monkeypatch):
+    """A geometry call triggers lazy load when the view isn't registered."""
+    # Force the lazy path: pretend nothing is loaded.
+    monkeypatch.setattr(core, "_overture_view_loaded", False)
+
+    called = {"count": 0}
+    real_ensure = core._ensure_overture_loaded
+
+    def spy_ensure():
+        called["count"] += 1
+        real_ensure()
+
+    monkeypatch.setattr(core, "_ensure_overture_loaded", spy_ensure)
+
+    wkls.us.ca.sanfrancisco.wkt()
+    assert called["count"] == 1, "geometry call must trigger exactly one lazy load"
+
+
+def test_offline_geometry_raises_connection_error(monkeypatch):
+    """When S3 is unreachable, the first geometry call surfaces a clear error."""
+    # Force a cold state and unresolved version so the lazy path must
+    # go through _list_s3_releases — which we break.
+    monkeypatch.setattr(core, "_overture_view_loaded", False)
+    monkeypatch.setattr(core, "_current_overture_version", None)
+
+    def blocked(*args, **kwargs):
+        raise urllib.error.URLError("simulated offline")
+
+    monkeypatch.setattr(urllib.request, "urlopen", blocked)
+
+    with pytest.raises(ConnectionError, match="Overture Maps releases"):
+        wkls.us.ca.sanfrancisco.wkt()

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -56,6 +56,11 @@ _S3_DIVISION_AREA_SUFFIX = "theme=divisions/type=division_area/"
 # Module-level state for the active Overture version
 _current_overture_version: str | None = None
 
+# True once the remote GeoParquet has been registered as the
+# ``overture`` SedonaDB view. Flipped by ``_ensure_overture_loaded``
+# (lazy, on first geometry call) or by ``configure()``.
+_overture_view_loaded: bool = False
+
 
 def _list_s3_releases() -> list[str]:
     """List all available Overture Maps releases on S3.
@@ -161,17 +166,16 @@ def _log_and_query(
 
 
 def _initialize_table() -> sedonadb.SedonaContext:
-    """Initialize the wkls table and Overture data views.
+    """Initialize the SedonaDB context and register the local metadata view.
 
-    Creates SedonaDB views for the local metadata table and remote
-    Overture Maps GeoParquet data. Auto-detects the latest Overture
-    release unless overridden by the ``WKLS_OVERTURE_VERSION`` env var.
+    Creates the ``wkls`` SedonaDB view from the bundled local parquet —
+    pure local I/O, no network. The remote ``overture`` view is
+    registered lazily by ``_ensure_overture_loaded`` on first geometry
+    call, so ``import wkls`` stays offline-safe.
 
     Returns:
         Configured SedonaContext instance.
     """
-    global _current_overture_version
-
     sedona = sedonadb.connect()
 
     # Enable interactive mode for auto-display
@@ -186,19 +190,40 @@ def _initialize_table() -> sedonadb.SedonaContext:
         f"{importlib.resources.files(data)}/overture.zstd18.parquet"
     ).to_view("wkls")
 
-    _current_overture_version = _resolve_overture_version()
+    return sedona
+
+
+# Initialize the table when the module is imported
+sedona = _initialize_table()
+
+
+def _ensure_overture_loaded() -> None:
+    """Register the remote Overture GeoParquet view on first geometry access.
+
+    Resolves the active Overture version (via ``WKLS_OVERTURE_VERSION``,
+    module-level cache, or an S3 listing), then registers the remote
+    GeoParquet as the ``overture`` SedonaDB view. Idempotent — later
+    calls short-circuit on ``_overture_view_loaded``. ``configure()``
+    sets the flag too, so a user-driven reload keeps the fast path.
+
+    Raises:
+        ConnectionError: If the S3 listing or parquet read fails. The
+            message points at the network requirement.
+    """
+    global _current_overture_version, _overture_view_loaded
+    if _overture_view_loaded:
+        return
+    if _current_overture_version is None:
+        _current_overture_version = _resolve_overture_version()
     sedona.read_parquet(
         _overture_uri(_current_overture_version),
         options={
             "aws.skip_signature": True,
             "aws.region": "us-west-2",
         },
-    ).to_view("overture")
-    return sedona
+    ).to_view("overture", overwrite=True)
+    _overture_view_loaded = True
 
-
-# Initialize the table when the module is imported
-sedona = _initialize_table()
 
 # Cache for country identifier -> (canonical ISO, has_region).
 # Keyed by the lowercased raw identifier (ISO or name); populated once per
@@ -739,18 +764,25 @@ class Wkl:
         """Return the version of the Overture Maps dataset being used.
 
         This method is only available at the root level (wkls.overture_version()),
-        not on chained objects.
+        not on chained objects. Resolves the version lazily on first
+        call — this is an S3 listing request, so it requires network
+        access (but is cheap compared to loading the parquet itself).
 
         Returns:
             Version string of the Overture Maps dataset.
 
         Raises:
             ValueError: If called on a chained object.
+            ConnectionError: If the version hasn't been resolved yet
+                and the S3 listing fails.
         """
+        global _current_overture_version
         if self.chain:
             raise ValueError(
                 "overture_version() is only available at the root level. Use wkls.overture_version(), not wkls.us.overture_version()."
             )
+        if _current_overture_version is None:
+            _current_overture_version = _resolve_overture_version()
         return _current_overture_version
 
     def overture_releases(self) -> list[str]:
@@ -798,7 +830,7 @@ class Wkl:
             >>> wkls.overture_version()
             '2025-12-17.0'
         """
-        global _current_overture_version
+        global _current_overture_version, _overture_view_loaded
 
         if self.chain:
             raise ValueError(
@@ -826,6 +858,7 @@ class Wkl:
                 "aws.region": "us-west-2",
             },
         ).to_view("overture", overwrite=True)
+        _overture_view_loaded = True
 
     def __getattr__(self, attr: str) -> Any:
         """Handle attribute access.
@@ -1281,7 +1314,10 @@ class Wkl:
         Raises:
             ValueError: If no results found or no geometry exists.
             AmbiguousLocationError: If the resolved DataFrame has >1 row.
+            ConnectionError: If the remote Overture data can't be
+                registered (first geometry call only; requires S3 access).
         """
+        _ensure_overture_loaded()
         df = self.resolve()
         row_count = df.count()
         if row_count == 0:


### PR DESCRIPTION
## Summary
- `_initialize_table()` used to fetch from S3 at import time, so any transient network failure (hit in a notebook cell this week — 58s of retries) crashed `import wkls` entirely. This has been the behavior since the DuckDB → SedonaDB migration; CI never caught it because CI has reliable S3.
- The remote GeoParquet is only needed for geometry output (`.wkt()` / `.wkb()` / `.geojson()`). Chain resolution, search, listing, navigation, and introspection all run against the bundled local metadata.
- Moves the S3 version-resolve and overture-view registration into a lazy `_ensure_overture_loaded()` helper, fired on first geometry call. `configure()` still eagerly reloads when the user explicitly asks for a version.

## Why now
Agents often run in sandboxed or offline environments. A library that can't import without the network is effectively broken for that audience. This fix makes `import wkls` + catalog exploration work fully offline; geometry is the only method class that requires S3.

## Test plan
- [ ] CI — full suite (124 passed, 2 xfailed locally)
- [ ] `tests/test_lazy_overture.py` — new file, 4 cases:
  - `test_import_without_network_subprocess` — `import wkls` + catalog surfaces in a subprocess with `urlopen` mocked to raise
  - `test_ensure_overture_loaded_is_idempotent` — second call short-circuits
  - `test_geometry_triggers_overture_load` — `.wkt()` fires the lazy load exactly once
  - `test_offline_geometry_raises_connection_error` — clean `ConnectionError` when S3 is unreachable

## Out of scope
- Caching the Overture parquet locally for full offline geometry — separate story.
- Transparent S3 retry beyond what SedonaDB already does (10×).