### PR TITLE
feat: agent-oriented docstring, AGENTS.md, and Wkl.__repr__ state header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# Using wkls from an AI agent
+
+`wkls` gives you administrative-boundary geometries (countries,
+regions, counties, cities) from Overture Maps via chainable Python
+attributes. No API keys, no setup.
+
+## The five things you'll actually do
+
+### 1. Get a geometry
+
+```python
+import wkls
+
+wkls.us.ca.sanfrancisco.wkt()      # WKT string
+wkls.india.maharashtra.geojson()   # GeoJSON string
+wkls.de.wkb()                      # WKB bytes
+```
+
+Chain is `<country>.<region>.<city>` — max 3 levels for unambiguous
+cases. Names are lowercased, non-alphanumerics stripped. ISO codes
+work too: `wkls.us.ca.sanfrancisco` or
+`wkls.unitedstates.california.sanfrancisco`.
+
+### 2. Handle ambiguity
+
+When a chain resolves to multiple rows, geometry methods raise
+`AmbiguousLocationError` (a subclass of `ValueError`). The message
+lists every candidate with its subtype, parent name, and UUID.
+
+Three dot-faithful ways to narrow:
+
+```python
+# Subtype modifier — when candidates differ by kind
+wkls.us.ca.mission.locality        # the city of Mission
+wkls.us.ca.mission.county          # Mission County
+
+# 4-level parent narrower — name the parent in the chain
+wkls.us.pa.adamscounty.franklin    # Franklin in Adams County, PA
+
+# Escape hatch — pick by the UUID shown in the error message
+wkls.by_id('273bc9a0-96a1-402c-992c-84f5c2f212cb').wkt()
+```
+
+### 3. Find things by name
+
+`.search(q)` at any chain depth. Scope narrows with depth. Query is
+normalized (lowercased, non-alphanumerics stripped), so
+`"san francisco"`, `"San Francisco"`, and `"sanfrancisco"` match the
+same rows.
+
+```python
+wkls.search("mission")             # anywhere in the dataset
+wkls.us.search("mission")          # anywhere in the US
+wkls.us.ca.search("mission")       # anywhere in California
+```
+
+Returns a `Wkl` — single-row results support `.wkt()` directly;
+multi-row results support subtype modifiers to narrow further.
+
+### 4. Navigate the hierarchy
+
+```python
+wkls.us.ca.sanfrancisco.parent     # → California (one level up)
+wkls.us.ca.sanfrancisco.path       # 'wkls.us.ca.sanfrancisco'
+                                   #   (round-trips through eval)
+```
+
+### 5. List subtrees
+
+```python
+wkls.countries()                   # all countries
+wkls.us.regions()                  # regions in the US
+wkls.us.ca.counties()              # counties in California
+wkls.us.ca.sandiegocounty.cities() # cities in San Diego County
+```
+
+## The single return type
+
+Every attribute / method returns a `Wkl`. Inspection methods:
+
+- `.count()` — number of rows
+- `.head(n)` / `.to_arrow_table()` — see the rows
+- `.wkt()` / `.wkb()` / `.geojson()` — geometry (requires exactly 1 row)
+- `.path` — dot-access path (requires single row)
+- `.parent` — hierarchy walk (requires single row, not at country level)
+
+`dir(wkl_instance)` returns only the methods that are valid for the
+current state — use it to discover what's available.
+
+## Error model
+
+- `AmbiguousLocationError` (subclass of `ValueError`) — geometry on a
+  multi-row `Wkl`. Message lists candidates and suggests narrowers.
+- `ValueError` — empty chain, chain too deep, `.parent` at country
+  level, listing methods called on an ambiguous chain.
+- Chain attributes that don't resolve return a `Wkl` with
+  `.count() == 0` rather than raising.
+
+## Common gotchas
+
+- Diacritics aren't folded: `wkls.ivorycoast` won't resolve because
+  `name_en` is "Côte d'Ivoire". Use the ISO code: `wkls.ci`.
+- `Wkl()[...]` bracket access is deprecated; use dot access or
+  `.search()`.
+- Don't call geometry methods on a multi-row result — check
+  `.count() == 1` first, or use one of the narrowers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dev = [
     "ruff>=0.11.12",
 ]
 
+[tool.hatch.build.targets.wheel.force-include]
+"AGENTS.md" = "wkls/AGENTS.md"
+
 [tool.setuptools.package-data]
 wkls = ["data/overture.zstd18.parquet", "py.typed"]
 

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -71,6 +71,68 @@ def test_version_attribute():
     assert len(wkls.__version__) > 0
 
 
+def test_llm_guide_attribute():
+    """__llm_guide__ ships the AGENTS.md reference for runtime access."""
+    assert hasattr(wkls, "__llm_guide__")
+    guide = wkls.__llm_guide__
+    assert isinstance(guide, str)
+    # Sanity-check the content covers the core agent-relevant surface.
+    for phrase in (
+        "Using wkls from an AI agent",
+        "AmbiguousLocationError",
+        "by_id(",
+        ".search(",
+        ".parent",
+        ".path",
+    ):
+        assert phrase in guide, f"missing from __llm_guide__: {phrase!r}"
+
+
+def test_repr_header_root():
+    """Root Wkl() repr is a terse label."""
+    assert repr(Wkl()) == "Wkl(root)"
+
+
+def test_repr_header_single_row_chain():
+    """A resolved single-row chain advertises path, rows, and subtype."""
+    header = repr(wkls.us.ca.sanfrancisco).split("\n")[0]
+    assert header.startswith("Wkl(")
+    assert "path='wkls.us.ca.sanfrancisco'" in header
+    assert "rows=1" in header
+    assert "subtype='county'" in header
+
+
+def test_repr_header_multi_row_chain():
+    """An ambiguous chain uses chain= rather than path= and shows row count."""
+    header = repr(wkls.us.pa.franklin).split("\n")[0]
+    assert "chain='wkls.us.pa.franklin'" in header
+    assert "rows=18" in header
+
+
+def test_repr_header_result_mode_multi_row():
+    """Multi-row results show a subtype breakdown dict."""
+    header = repr(wkls.us.ca.search("san")).split("\n")[0]
+    assert header.startswith("Wkl(rows=")
+    assert "subtypes=" in header
+
+
+def test_repr_header_empty_result():
+    """Empty result-mode Wkl shows rows=0 with no subtype info."""
+    header = repr(wkls.us.ca.search("zzznope")).split("\n")[0]
+    assert header == "Wkl(rows=0)"
+
+
+def test_module_docstring_leads_with_quickstart():
+    """help(wkls) should show agents the key patterns within the first screen."""
+    doc = wkls.__doc__ or ""
+    assert "Quickstart:" in doc
+    # Disambiguation must be advertised up front, not buried.
+    assert "AmbiguousLocationError" in doc
+    assert "subtype modifier" in doc
+    assert "parent narrower" in doc
+    assert "by_id(" in doc
+
+
 # ---------- Basic chain access smoke ----------
 
 

--- a/wkls/__init__.py
+++ b/wkls/__init__.py
@@ -1,12 +1,55 @@
-"""wkls — Well-Known Locations.
+"""wkls — Well-Known Locations. Administrative boundaries via dot access.
 
-Provides chainable access to Overture Maps administrative boundary geometries
-via Apache SedonaDB. Two usage patterns, both supported:
+Quickstart:
 
-    >>> import wkls                          # module-level ergonomic access
+    >>> import wkls
+    >>> wkls.us.ca.sanfrancisco.wkt()      # geometry as WKT string
+    >>> wkls.india.maharashtra.geojson()   # or GeoJSON, or wkb()
+
+Chain depth maps to the admin hierarchy (max 3 for unambiguous cases):
+
+    wkls.<country>                         # country / dependency
+    wkls.<country>.<region>                # state / province
+    wkls.<country>.<region>.<city>         # county / locality / localadmin
+
+Names are lowercased with non-alphanumerics stripped; ISO codes work
+too: wkls.us, wkls.unitedstates, wkls.us.ca, wkls.us.california.
+
+When a chain resolves to >1 row, geometry methods raise
+AmbiguousLocationError (a ValueError subclass). Three dot-faithful
+ways to narrow, plus an escape hatch:
+
+    wkls.us.ca.mission.locality            # subtype modifier
+    wkls.us.pa.adamscounty.franklin        # 4-level parent narrower
+    wkls.by_id('273bc9a0-...')             # exact pick (UUID from
+                                           #   the error message)
+
+Navigation and introspection:
+
+    wkls.us.ca.sanfrancisco.parent         # → California
+    wkls.us.ca.sanfrancisco.path           # 'wkls.us.ca.sanfrancisco'
+    wkls.us.ca.search('mission')           # substring search, any depth
+
+Listing scopes narrow with chain depth:
+
+    wkls.countries()                       # all 219 countries
+    wkls.us.regions()                      # 51 US regions
+    wkls.us.ca.counties()                  # 58 CA counties
+    wkls.us.ca.sandiegocounty.cities()     # 19 localities in SD County
+
+Every call returns a Wkl — one unified type. Inspect with .count(),
+.head(), .to_arrow_table(); extract geometry with .wkt() / .wkb() /
+.geojson() when the Wkl holds exactly one row.
+
+For the full agent reference including error handling patterns:
+    >>> print(wkls.__llm_guide__)
+
+Two ways to use the library:
+
+    >>> import wkls                        # module-level ergonomics
     >>> wkls.us.ca.sanfrancisco.wkt()
 
-    >>> from wkls import Wkl                 # explicit instantiation
+    >>> from wkls import Wkl               # explicit instantiation
     >>> wkl = Wkl()
     >>> wkl.us.ca.sanfrancisco.wkt()
 """

--- a/wkls/__init__.py
+++ b/wkls/__init__.py
@@ -57,6 +57,7 @@ Two ways to use the library:
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 from typing import Any
 
 from .core import Wkl
@@ -67,6 +68,20 @@ try:
     __version__ = version("wkls")
 except PackageNotFoundError:
     __version__ = "0.0.0.dev"
+
+
+def _load_llm_guide() -> str:
+    """Load AGENTS.md from the installed wheel or the dev repo root."""
+    pkg_path = Path(__file__).parent / "AGENTS.md"
+    if pkg_path.exists():
+        return pkg_path.read_text(encoding="utf-8")
+    repo_path = Path(__file__).parent.parent / "AGENTS.md"
+    if repo_path.exists():
+        return repo_path.read_text(encoding="utf-8")
+    return ""
+
+
+__llm_guide__: str = _load_llm_guide()
 
 
 _instance: Wkl | None = None
@@ -98,7 +113,7 @@ def __getattr__(name: str) -> Any:
 
 
 def __dir__() -> list[str]:
-    module_attrs = list(__all__) + ["__version__"]
+    module_attrs = list(__all__) + ["__version__", "__llm_guide__"]
     try:
         wkl_attrs = dir(_get_instance())
     except Exception:

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1109,15 +1109,21 @@ class Wkl:
         Three shapes:
 
         - **Root** (empty chain, no DataFrame): short friendly label.
-        - **Chain-mode**: the DataFrame repr, plus a "Did you mean?"
-          + ``.search()`` hint when no rows matched.
+        - **Chain-mode**: a one-line state header (path/chain, rows,
+          subtype breakdown), then the DataFrame table, plus a "Did
+          you mean?" + ``.search()`` hint when no rows matched.
         - **Result-mode** (empty chain, cached DataFrame from a
-          listing/search call): just the DataFrame repr.
+          listing/search call): header + DataFrame table.
+
+        The state header is designed so callers — especially AI agents
+        doing multi-turn work — can read their own state at a glance
+        without an extra ``.count()`` call.
         """
         if not self.chain and self._df is None:
-            return "<wkls.Wkl root>"
+            return "Wkl(root)"
 
         base_repr = repr(self.resolve())
+        header = self._repr_header()
 
         if self.chain:
             # Detect empty result by scanning the repr for the "header
@@ -1132,8 +1138,67 @@ class Wkl:
             if is_empty:
                 suggestions = self._get_suggestions(self.chain[-1])
                 hint = _build_error_hint(self.chain, suggestions) + "\n"
-                return hint + base_repr
-        return base_repr
+                return f"{header}\n{hint}{base_repr}"
+        return f"{header}\n{base_repr}"
+
+    def _repr_header(self) -> str:
+        """One-line state header: path/chain, row count, subtype breakdown.
+
+        Formatted so an agent inspecting a ``Wkl`` can see its mode and
+        size at a glance. ``path=`` is used when the chain resolves to a
+        single row (round-trippable); ``chain=`` is used otherwise.
+        """
+        parts: list[str] = []
+        if self.chain:
+            path_str = "wkls." + ".".join(self.chain)
+            key = "path" if self._is_single_row() else "chain"
+            parts.append(f"{key}='{path_str}'")
+
+        row_count = self._safe_row_count()
+        parts.append(f"rows={row_count}")
+
+        if row_count >= 1:
+            subtypes = self._subtype_counts()
+            if len(subtypes) == 1:
+                st = next(iter(subtypes))
+                parts.append(f"subtype='{st}'")
+            elif subtypes:
+                body = ", ".join(f"{k}: {v}" for k, v in subtypes.items())
+                parts.append(f"subtypes={{{body}}}")
+
+        return f"Wkl({', '.join(parts)})"
+
+    def _is_single_row(self) -> bool:
+        """True iff the resolved DataFrame holds exactly one row."""
+        try:
+            df = self._df if self._df is not None else self.resolve()
+            return df.count() == 1
+        except Exception:
+            return False
+
+    def _safe_row_count(self) -> int:
+        """Best-effort row count; 0 on failure so repr never throws."""
+        try:
+            df = self._df if self._df is not None else self.resolve()
+            return int(df.count())
+        except Exception:
+            return 0
+
+    def _subtype_counts(self) -> dict[str, int]:
+        """Distinct subtypes with row counts, ordered by count descending."""
+        try:
+            df = self._df if self._df is not None else self.resolve()
+            df.to_view("_wkls_repr_subtypes", overwrite=True)
+            tbl = sedona.sql(
+                "SELECT subtype, COUNT(*) AS n FROM _wkls_repr_subtypes "
+                "GROUP BY subtype ORDER BY n DESC"
+            ).to_arrow_table()
+            return {
+                tbl.column("subtype")[i].as_py(): tbl.column("n")[i].as_py()
+                for i in range(tbl.num_rows)
+            }
+        except Exception:
+            return {}
 
     def resolve(self) -> sedonadb.dataframe.DataFrame:
         """Resolve the location chain to a DataFrame.


### PR DESCRIPTION
## Summary
Three additive changes that make `wkls` easy to use for LLM agents reading the library cold via `help(wkls)`:

- **Module docstring** — `help(wkls)` now leads with an agent-oriented quickstart covering the canonical chain, disambiguation (`AmbiguousLocationError` + the three narrowers), navigation (`.parent` / `.path`), and listing. Replaces the 7-line "two usage patterns" stub.
- **`AGENTS.md` + `wkls.__llm_guide__`** — a single-page, system-prompt-ready reference at the repo root. Bundled into the wheel via hatch `force-include` and exposed at runtime as `wkls.__llm_guide__` so an agent can fetch it via `import wkls; print(wkls.__llm_guide__)`.
- **`Wkl.__repr__` state header** — prepends a single-line summary (path / chain, rows, subtype breakdown) above the existing DataFrame table. Agents doing multi-turn work can now see their own state at a glance; humans in REPL / Jupyter get the same table they had before.

## Why
For an agent reading `help(wkls)` cold, the disambiguation surface used to be buried several docstring sections deep. The default `__repr__` showed a table but no state summary, so agents had to burn tool calls on `.count()` to know what they were holding. This PR fixes both without changing any public API.

## Stacked on
#55 (lazy-load) — merge that first, then this PR's base will auto-retarget to `main`.

## Test plan
- [ ] CI — full suite (131 passed, 2 xfailed locally)
- [ ] `help(wkls)` first screen shows the quickstart + disambiguation
- [ ] `wkls.__llm_guide__` returns the AGENTS.md content (~3.6 KB)
- [ ] `repr(wkls.us.ca.sanfrancisco)` leads with `Wkl(path='wkls.us.ca.sanfrancisco', rows=1, subtype='county')`
- [ ] `repr(wkls.us.pa.franklin)` leads with `Wkl(chain='wkls.us.pa.franklin', rows=18, subtype='locality')`