### PR TITLE
feat: consistent scoping across all listing methods

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -4,9 +4,10 @@ Covers how users find out what's available:
 
 - ``dir(wkls)`` / ``dir(wkls.us)`` introspection.
 - ``.search(query)`` at each chain level with subtree scope.
-- Subtree-scoped listing methods (``.regions()``, ``.counties()``, ``.cities()``).
-- Root-only methods: ``.countries()``, ``.dependencies()``, ``.subtypes()``,
-  ``.overture_version()`` / ``.overture_releases()``.
+- Scoped listing methods — ``.countries()``, ``.dependencies()``,
+  ``.regions()``, ``.counties()``, ``.cities()``, ``.subtypes()`` —
+  all narrow with chain depth, inclusive of self where subtype matches.
+- Root-only config methods: ``.overture_version()`` / ``.overture_releases()``.
 """
 
 from __future__ import annotations
@@ -335,9 +336,15 @@ def test_regions_past_region_level_returns_empty():
     assert wkls.us.ca.sanfrancisco.regions().count() == 0
 
 
-def test_counties_past_region_level_returns_empty():
-    """counties() past region level cascades via parent_id; a locality has no sub-counties."""
-    assert wkls.us.ca.sanfrancisco.counties().count() == 0
+def test_counties_past_region_level_self_inclusive():
+    """counties() past region level includes self if self is a county.
+
+    Overture models San Francisco as a county (consolidated
+    city-county), so .counties() on it returns [SF].
+    """
+    result = wkls.us.ca.sanfrancisco.counties()
+    assert result.count() == 1
+    assert result.to_arrow_table().column("name_primary")[0].as_py() == "San Francisco"
 
 
 def test_cities_at_county_level_returns_children():
@@ -376,22 +383,94 @@ def test_subtypes_at_root():
         assert expected in subtype_values, f"Missing subtype: {expected}"
 
 
-def test_countries_hidden_on_chain():
-    """countries() is root-only and hidden from chained Wkl instances."""
-    assert not hasattr(wkls.us, "countries")
-    with pytest.raises(AttributeError):
-        wkls.us.countries()
+def test_countries_scope_narrows_to_self_on_country_chain():
+    """wkls.us.countries() returns [US] — the country that contains the chain."""
+    result = wkls.us.countries()
+    assert result.count() == 1
+    tbl = result.to_arrow_table()
+    assert tbl.column("country")[0].as_py() == "US"
+    assert tbl.column("subtype")[0].as_py() == "country"
 
 
-def test_dependencies_hidden_on_chain():
-    """dependencies() is root-only and hidden from chained Wkl instances."""
-    assert not hasattr(wkls.us, "dependencies")
-    with pytest.raises(AttributeError):
-        wkls.us.dependencies()
+def test_countries_scope_narrows_to_self_past_country_chain():
+    """countries() at region or city depth still returns the containing country."""
+    assert wkls.us.ca.countries().count() == 1
+    assert wkls.us.ca.sanfrancisco.countries().count() == 1
 
 
-def test_subtypes_hidden_on_chain():
-    """subtypes() is root-only and hidden from chained Wkl instances."""
-    assert not hasattr(wkls.us, "subtypes")
-    with pytest.raises(AttributeError):
-        wkls.us.subtypes()
+def test_dependencies_scope_empty_on_country_chain():
+    """wkls.us.dependencies() returns [] — US is a country, no dependencies in scope."""
+    assert wkls.us.dependencies().count() == 0
+
+
+def test_dependencies_scope_narrows_to_self_on_dependency_chain():
+    """wkls.pr.dependencies() returns [PR] — PR's subtype is 'dependency'."""
+    result = wkls.pr.dependencies()
+    assert result.count() == 1
+    tbl = result.to_arrow_table()
+    assert tbl.column("country")[0].as_py() == "PR"
+    assert tbl.column("subtype")[0].as_py() == "dependency"
+
+
+def test_subtypes_scope_narrows_to_country():
+    """wkls.us.subtypes() lists distinct subtypes present in the US."""
+    tbl = wkls.us.subtypes().to_arrow_table()
+    values = {tbl.column("subtype")[i].as_py() for i in range(tbl.num_rows)}
+    # US has country + region + county + locality at minimum.
+    assert {"country", "region", "county", "locality"}.issubset(values)
+
+
+def test_subtypes_scope_narrows_to_region():
+    """wkls.us.ca.subtypes() lists distinct subtypes present in CA."""
+    tbl = wkls.us.ca.subtypes().to_arrow_table()
+    values = {tbl.column("subtype")[i].as_py() for i in range(tbl.num_rows)}
+    # CA is itself a region; its subtree adds county + locality + localadmin.
+    assert "region" in values
+    assert values & {"county", "locality", "localadmin"}
+
+
+def test_subtypes_no_region_scope():
+    """Entities without regions in their subtree (e.g. Falklands) don't list 'region'.
+
+    FK is itself a dependency, so its subtype scope is {dependency, locality}.
+    """
+    tbl = wkls.fk.subtypes().to_arrow_table()
+    values = {tbl.column("subtype")[i].as_py() for i in range(tbl.num_rows)}
+    assert "region" not in values
+    assert "dependency" in values  # FK is a dependency
+    assert "locality" in values  # FK has localities
+
+
+def test_subtypes_past_region_level_requires_single_row():
+    """subtypes() past region level matches the other list-method single-row rule."""
+    with pytest.raises(ValueError, match="single row"):
+        wkls.us.pa.franklin.subtypes()
+
+
+def test_cities_at_locality_level_includes_self():
+    """cities() on a single-row locality chain includes self.
+
+    Consistency: ``regions()`` at region level returns the region itself;
+    ``cities()`` at locality level should return the locality itself.
+    Oakland is a locality (San Francisco is modelled as a county in
+    Overture, so it's tested via counties() instead).
+    """
+    oakland = wkls.us.ca.alamedacounty.oakland
+    cities = oakland.cities()
+    assert cities.count() >= 1
+    names = {
+        cities.to_arrow_table().column("name_primary")[i].as_py()
+        for i in range(cities.count())
+    }
+    assert "Oakland" in names
+
+
+def test_counties_at_county_level_includes_self():
+    """counties() on a single-row county chain returns the county itself."""
+    sf = wkls.us.ca.sanfrancisco
+    # Overture models SF as a county (consolidated city-county).
+    counties = sf.counties()
+    assert counties.count() == 1
+    tbl = counties.to_arrow_table()
+    assert tbl.column("name_primary")[0].as_py() == "San Francisco"
+    assert tbl.column("subtype")[0].as_py() == "county"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -157,8 +157,8 @@ def test_suggestions_via_Wkl_bracket_access(ignore_bracket_deprecation):
 # ---------- Error propagation on chained Wkl ----------
 
 
-def test_chainable_df_propagates_root_only_errors():
-    """Root-only methods are hidden on chained Wkl instances."""
-    us_df = wkls.us
-    with pytest.raises(AttributeError):
-        us_df.countries()
+def test_chainable_df_hides_root_only_config_methods():
+    """Config methods (configure, overture_*) are hidden on chained Wkls."""
+    us = wkls.us
+    for name in ("configure", "overture_version", "overture_releases"):
+        assert not hasattr(us, name), f"{name} should be hidden on chained Wkl"

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -386,11 +386,8 @@ class Wkl:
     _ROOT_ONLY_METHODS = frozenset(
         {
             "configure",
-            "countries",
-            "dependencies",
             "overture_releases",
             "overture_version",
-            "subtypes",
         }
     )
 
@@ -1504,48 +1501,56 @@ class Wkl:
         return pyarrow_wkb_array.__arrow_c_array__(requested_schema=requested_schema)
 
     def dependencies(self) -> Wkl:
-        """Get all dependencies (territories, overseas regions, etc.).
+        """List dependencies (territories, overseas regions, etc.) in scope.
+
+        Scope narrows with chain depth, matching the other listing
+        methods. ``wkls.dependencies()`` at root lists every dependency
+        in the dataset; at any other depth, results are filtered to
+        dependencies within the current country chain. A dependency
+        chain (e.g. ``wkls.pr``) returns itself.
 
         Returns:
-            A result-mode ``Wkl`` wrapping the matching rows (id,
-            country, subtype, name_primary, name_en).
-
-        Raises:
-            ValueError: If called on a chained object instead of root.
+            A result-mode ``Wkl`` wrapping the matching rows.
         """
-        if self.chain:
-            raise ValueError(
-                "dependencies() can only be called on the root object. Use wkls.dependencies() instead of chaining."
-            )
-
-        query = """
-            SELECT DISTINCT id, country, subtype, name_primary, name_en
-            FROM wkls
-            WHERE subtype = 'dependency'
-        """
-        return Wkl(_df=sedona.sql(query))
+        return self._list_top_level_subtype("dependency")
 
     def countries(self) -> Wkl:
-        """Get all countries.
+        """List countries in scope.
+
+        Scope narrows with chain depth, matching the other listing
+        methods. ``wkls.countries()`` at root lists every country in
+        the dataset; at any other depth, the result is the one country
+        that contains the current chain (``wkls.us.countries()`` →
+        ``[US]``).
 
         Returns:
-            A result-mode ``Wkl`` wrapping the matching rows (id,
-            country, subtype, name_primary, name_en).
-
-        Raises:
-            ValueError: If called on a chained object instead of root.
+            A result-mode ``Wkl`` wrapping the matching rows.
         """
-        if self.chain:
-            raise ValueError(
-                "countries() can only be called on the root object. Use wkls.countries() instead of chaining."
-            )
+        return self._list_top_level_subtype("country")
 
-        query = """
+    def _list_top_level_subtype(self, subtype: str) -> Wkl:
+        """Shared implementation for ``countries()`` / ``dependencies()``.
+
+        Both list a top-level subtype. At root, return every row of that
+        subtype. On any chain, filter by the current country so the
+        result is bound to the chain's scope (one row for the
+        matching country / dependency, or empty otherwise).
+        """
+        if not self.chain:
+            query = f"""
+                SELECT DISTINCT id, country, subtype, name_primary, name_en
+                FROM wkls
+                WHERE subtype = '{subtype}'
+            """
+            return Wkl(_df=sedona.sql(query))
+
+        query = f"""
             SELECT DISTINCT id, country, subtype, name_primary, name_en
             FROM wkls
-            WHERE subtype = 'country'
+            WHERE subtype = '{subtype}'
+              AND country = '{{country}}'
         """
-        return Wkl(_df=sedona.sql(query))
+        return Wkl(_df=sedona.sql(query.format(country=sqlescape(self._country_iso))))
 
     def regions(self) -> Wkl:
         """List regions in the current chain scope.
@@ -1612,8 +1617,12 @@ class Wkl:
                 )
             )
 
-        # Depth >= 3: parent-scoped. The chain must resolve to a single
-        # row; we list its direct children by parent_id.
+        # Depth >= 3: scope is self + direct descendants. The chain
+        # must resolve to a single row; we return that row (if its
+        # subtype matches the filter) plus any children whose subtype
+        # matches. This keeps the pattern consistent with depth 1-2
+        # (where ``regions()`` at region level returns the region row
+        # itself) — the current row is in-scope for its own subtype.
         df = self.resolve()
         row_count = df.count()
         if row_count != 1:
@@ -1625,10 +1634,10 @@ class Wkl:
         row_id = df.head(1).to_arrow_table().column("id")[0].as_py()
         query = f"""
             SELECT * FROM wkls
-            WHERE parent_id = '{{parent_id}}'
+            WHERE (id = '{{row_id}}' OR parent_id = '{{row_id}}')
               AND subtype IN {subtype_filter}
         """
-        return Wkl(_df=sedona.sql(query.format(parent_id=sqlescape(row_id))))
+        return Wkl(_df=sedona.sql(query.format(row_id=sqlescape(row_id))))
 
     def counties(self) -> Wkl:
         """List counties in the current chain scope.
@@ -1663,21 +1672,65 @@ class Wkl:
         return self._list_subtype("('locality', 'localadmin')", "cities")
 
     def subtypes(self) -> Wkl:
-        """Get all distinct division subtypes in the dataset.
+        """List distinct division subtypes in scope.
+
+        Scope narrows with chain depth, matching the other listing
+        methods. ``wkls.subtypes()`` at root enumerates every subtype
+        in the dataset; at a country or region chain, the result is
+        restricted to subtypes present within that scope (e.g.
+        ``wkls.fk.subtypes()`` shows the Falklands lack regions).
 
         Returns:
             A result-mode ``Wkl`` wrapping the distinct subtype rows.
 
         Raises:
-            ValueError: If called on a chained object instead of root.
+            ValueError: If the chain resolves to more than one row past
+                region level (same single-row requirement as
+                ``counties()`` / ``cities()``).
         """
-        if self.chain:
-            raise ValueError(
-                "subtypes() can only be called on the root object. Use wkls.subtypes() instead of chaining."
+        depth = len(self.chain)
+
+        if depth == 0:
+            return Wkl(_df=sedona.sql("SELECT DISTINCT subtype FROM wkls"))
+
+        if depth == 1 or not self._has_region:
+            query = """
+                SELECT DISTINCT subtype FROM wkls
+                WHERE country = '{country}'
+            """
+            return Wkl(
+                _df=sedona.sql(query.format(country=sqlescape(self._country_iso)))
             )
 
-        query = """SELECT DISTINCT subtype FROM wkls"""
-        return Wkl(_df=sedona.sql(query))
+        if depth == 2:
+            query = """
+                SELECT DISTINCT subtype FROM wkls
+                WHERE country = '{country}' AND region = '{region}'
+            """
+            return Wkl(
+                _df=sedona.sql(
+                    query.format(
+                        country=sqlescape(self._country_iso),
+                        region=sqlescape(self._region_iso),
+                    )
+                )
+            )
+
+        # Depth >= 3: scope is self + descendants (same semantics as
+        # counties()/cities() past region level).
+        df = self.resolve()
+        row_count = df.count()
+        if row_count != 1:
+            raise ValueError(
+                "subtypes() past region level requires the chain to resolve "
+                f"to a single row; '{'.'.join(self.chain)}' has {row_count} rows."
+            )
+        row_id = df.head(1).to_arrow_table().column("id")[0].as_py()
+        query = """
+            SELECT DISTINCT subtype FROM wkls
+            WHERE id = '{row_id}' OR parent_id = '{row_id}'
+        """
+        return Wkl(_df=sedona.sql(query.format(row_id=sqlescape(row_id))))
 
     def search(self, query: str) -> Wkl:
         """Search for locations whose names contain a substring.


### PR DESCRIPTION
## Summary
Uniform rule across every list-method: **`X()` returns `subtype=X` rows in my subtree, inclusive of self.** The previously root-only methods (`countries`, `dependencies`, `subtypes`) now scope with chain depth like `regions` / `counties` / `cities`, and the depth ≥ 3 case includes the current row when its subtype matches the filter.

## Before / after

| Call | Before | After |
|---|---|---|
| `wkls.us.countries()` | raises | `[US]` |
| `wkls.us.ca.countries()` | raises | `[US]` |
| `wkls.us.dependencies()` | raises | `[]` (US is a country) |
| `wkls.pr.dependencies()` | raises | `[PR]` (PR is a dependency) |
| `wkls.us.subtypes()` | raises | distinct subtypes in the US subtree |
| `wkls.fk.subtypes()` | raises | `{dependency, locality}` — FK has no regions |
| `wkls.us.ca.sanfrancisco.counties()` | `[]` | `[SF]` (SF is modelled as a county in Overture) |
| `wkls.us.ca.alamedacounty.oakland.cities()` | `[]` | `[Oakland]` (Oakland is a locality) |

## Why
Before: `regions()` at region level returned the region itself, but `countries()` on a country chain raised. Same conceptual call, different behavior. The inconsistency leaked into agent usability (agents had to remember which methods scope and which are root-only).

After: one rule. Scope narrows with chain depth; self is in-scope for its own subtype. Config methods (`configure`, `overture_version`, `overture_releases`) stay root-only — they're genuinely global, not hierarchical.

## Test plan
- [ ] CI — full suite (140 passed, 2 xfailed locally)
- [ ] `wkls.us.countries().count() == 1` with US as the row
- [ ] `wkls.pr.dependencies().count() == 1` with PR as the row
- [ ] `wkls.fk.subtypes()` does not include 'region'
- [ ] `wkls.us.ca.sanfrancisco.counties()` includes SF (self-inclusive)
- [ ] `wkls.us.ca.alamedacounty.oakland.cities()` includes Oakland (self-inclusive)
- [ ] `wkls.us.configure(...)` still raises `AttributeError` (config stays root-only)