### PR TITLE
fix: scoped methods narrow on result-mode (not just search)

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -277,6 +277,84 @@ def test_search_chains_on_root_result_still_narrows():
     assert second.count() < first.count()
 
 
+# ---------- Listing methods narrow on result-mode ----------
+
+
+def test_counties_narrows_on_result_mode():
+    """counties() on a result-mode Wkl filters the prior rows to counties.
+
+    Regression: previously fired a fresh global scan, returning tens
+    of thousands of counties unrelated to the prior search.
+    """
+    prior = wkls.us.search("san")
+    assert prior.count() > 1
+    narrowed = prior.counties()
+    prior_ids = {
+        prior.to_arrow_table().column("id")[i].as_py() for i in range(prior.count())
+    }
+    tbl = narrowed.to_arrow_table()
+    for i in range(tbl.num_rows):
+        assert tbl.column("subtype")[i].as_py() == "county"
+        assert tbl.column("id")[i].as_py() in prior_ids
+
+
+def test_cities_narrows_on_result_mode():
+    """cities() on a result-mode Wkl filters to locality/localadmin rows."""
+    prior = wkls.us.search("san")
+    narrowed = prior.cities()
+    subtypes = {
+        narrowed.to_arrow_table().column("subtype")[i].as_py()
+        for i in range(narrowed.count())
+    }
+    assert subtypes.issubset({"locality", "localadmin"})
+
+
+def test_countries_narrows_on_result_mode():
+    """countries() on a result-mode Wkl filters to country rows in the prior result."""
+    # A name that doesn't match any country — should narrow to empty.
+    assert wkls.search("franklin").countries().count() == 0
+    # A name that does — should include at least that country.
+    united = wkls.search("united").countries()
+    tbl = united.to_arrow_table()
+    subtypes = {tbl.column("subtype")[i].as_py() for i in range(tbl.num_rows)}
+    assert subtypes == {"country"}
+    assert united.count() >= 1
+
+
+def test_dependencies_narrows_on_result_mode():
+    """dependencies() on a result-mode Wkl filters to dependency rows."""
+    result = wkls.search("united").dependencies()
+    tbl = result.to_arrow_table()
+    for i in range(tbl.num_rows):
+        assert tbl.column("subtype")[i].as_py() == "dependency"
+
+
+def test_subtypes_narrows_on_result_mode():
+    """subtypes() on a result-mode Wkl lists distinct subtypes in the prior rows."""
+    result = wkls.us.search("san").subtypes()
+    vals = {
+        result.to_arrow_table().column("subtype")[i].as_py()
+        for i in range(result.count())
+    }
+    # Must be a subset of real subtypes (no spurious global ones).
+    assert vals <= {
+        "country",
+        "dependency",
+        "region",
+        "county",
+        "locality",
+        "localadmin",
+    }
+    assert len(vals) >= 1
+
+
+def test_config_methods_still_hidden_on_result_mode():
+    """configure / overture_* are genuinely global — still hidden on result-mode."""
+    r = wkls.search("san")
+    for name in ("configure", "overture_version", "overture_releases"):
+        assert not hasattr(r, name), f"{name} should be hidden on result-mode"
+
+
 # ---------- to_dicts() ----------
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -240,6 +240,43 @@ def test_search_normalizes_query_to_dot_access_form():
     assert spaceless >= 1  # at least the SF locality
 
 
+def test_search_chains_narrow_within_prior_result():
+    """A second ``.search()`` on a result-mode Wkl narrows within the
+    prior rows rather than firing a fresh global scan.
+
+    Regression: ``wkls.us.ca.search('san').search('san francisco')``
+    used to bail out of the chain and run SEARCH_ROOT, returning
+    global matches from every country. After the fix it stays within
+    the US/CA scope.
+    """
+    narrowed = wkls.us.ca.search("san").search("san francisco")
+    tbl = narrowed.to_arrow_table()
+    countries = {tbl.column("country")[i].as_py() for i in range(tbl.num_rows)}
+    regions = {tbl.column("region")[i].as_py() for i in range(tbl.num_rows)}
+    # Must be a subset of the prior scope (US/CA).
+    assert countries == {"US"}
+    assert regions == {"US-CA"}
+    # Must match the single-call equivalent (same final scope, same query).
+    single = wkls.us.ca.search("san francisco").count()
+    assert narrowed.count() == single
+
+
+def test_search_chains_on_root_result_still_narrows():
+    """A chained search on a root-level result narrows within it too."""
+    first = wkls.search("francisco")  # root-level, many countries
+    second = first.search("san")
+    # Every row in `second` must also be in `first` — narrowing, not
+    # re-scanning.
+    first_ids = {
+        first.to_arrow_table().column("id")[i].as_py() for i in range(first.count())
+    }
+    second_ids = {
+        second.to_arrow_table().column("id")[i].as_py() for i in range(second.count())
+    }
+    assert second_ids.issubset(first_ids)
+    assert second.count() < first.count()
+
+
 # ---------- to_dicts() ----------
 
 

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1735,16 +1735,21 @@ class Wkl:
     def search(self, query: str) -> Wkl:
         """Search for locations whose names contain a substring.
 
-        Searches every row within the current chain's scope — countries,
-        dependencies, regions, counties, and localities alike — and returns
-        matches as a result-mode ``Wkl``. Rows carry a ``subtype`` column
-        so callers can tell what they got back.
+        Searches every row within the current ``Wkl``'s scope —
+        countries, dependencies, regions, counties, and localities
+        alike — and returns matches as a result-mode ``Wkl``. Rows
+        carry a ``subtype`` column so callers can tell what they got
+        back.
 
-        The scope narrows with chain depth:
+        Scope is determined by the current ``Wkl``:
 
-        - ``wkls.search(q)``        — full dataset
-        - ``wkls.us.search(q)``     — everything under US
-        - ``wkls.us.ca.search(q)``  — everything under California
+        - **Root** (``wkls.search(q)``): full dataset.
+        - **Chain-mode** (``wkls.us.search(q)`` /
+          ``wkls.us.ca.search(q)``): scoped to that country or region.
+        - **Result-mode** (the output of a previous search or listing
+          call): narrows *within* the current rows, so chained calls
+          like ``wkls.us.ca.search('san').search('san francisco')``
+          progressively filter the same result set.
 
         Args:
             query: Search string. Matched against normalized forms of
@@ -1754,17 +1759,17 @@ class Wkl:
                 and ``"sanfrancisco"`` all match the same rows.
 
         Returns:
-            A result-mode ``Wkl`` of matching rows (id, country, region,
-            subtype, name_primary, name_en).
+            A result-mode ``Wkl`` of matching rows.
 
         Raises:
             ValueError: If called past city level (chain depth > 2).
 
         Examples:
             >>> import wkls
-            >>> wkls.search("san francisco")     # finds the city from root
-            >>> wkls.us.search("los angeles")    # scoped to US
-            >>> wkls.us.ca.search("san fran")    # scoped to California
+            >>> wkls.search("san francisco")              # full dataset
+            >>> wkls.us.search("los angeles")             # scoped to US
+            >>> wkls.us.ca.search("san")                  # scoped to CA
+            >>> wkls.us.ca.search("san").search("fran")   # narrow within
         """
         depth = len(self.chain)
         if depth > 2:
@@ -1776,6 +1781,17 @@ class Wkl:
         # Normalize to the dot-access form so ``search("sanfrancisco")``
         # and ``search("San Francisco")`` both match "San Francisco".
         escaped_query = sqlescape(_normalize_name(query))
+
+        # Result-mode: narrow within the already-resolved rows. The
+        # previous search/listing call has already scoped the data; a
+        # fresh global scan would ignore that scope entirely.
+        if depth == 0 and self._df is not None:
+            view_name = "_wkls_search_within"
+            self._df.to_view(view_name, overwrite=True)
+            sql = queries.SEARCH_WITHIN_VIEW.format(
+                view_name=view_name, query=escaped_query
+            )
+            return Wkl(_df=sedona.sql(sql))
 
         if depth == 0:
             sql = queries.SEARCH_ROOT.format(query=escaped_query)

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -381,8 +381,11 @@ class Wkl:
     _has_region: bool = True
 
     # Methods that only make sense on the root `Wkl`. Hidden from chained
-    # and result-mode instances so `hasattr(wkls.us, "configure")` is False,
-    # matching the pre-unification contract.
+    # instances so `hasattr(wkls.us, "configure")` is False — matching the
+    # pre-unification contract. ``_LISTING_ROOT_METHODS`` is the subset
+    # that, while hidden on chain-mode, *is* allowed through on
+    # result-mode (empty chain + cached DataFrame) so it can narrow
+    # within the prior result. Config methods stay strictly root-only.
     _ROOT_ONLY_METHODS = frozenset(
         {
             "configure",
@@ -390,6 +393,7 @@ class Wkl:
             "overture_version",
         }
     )
+    _LISTING_ROOT_METHODS = frozenset({"countries", "dependencies", "subtypes"})
 
     def __getattribute__(self, name: str) -> Any:
         if name in type(self)._ROOT_ONLY_METHODS:
@@ -397,7 +401,13 @@ class Wkl:
             # this hook — use object.__getattribute__.
             chain = object.__getattribute__(self, "chain")
             df = object.__getattribute__(self, "_df")
-            if chain or df is not None:
+            if chain:
+                raise AttributeError(
+                    f"'{type(self).__name__}' object has no attribute '{name}'"
+                )
+            # Result-mode (df set, no chain): listing methods pass
+            # through to narrow; config methods stay blocked.
+            if df is not None and name not in type(self)._LISTING_ROOT_METHODS:
                 raise AttributeError(
                     f"'{type(self).__name__}' object has no attribute '{name}'"
                 )
@@ -1503,11 +1513,14 @@ class Wkl:
     def dependencies(self) -> Wkl:
         """List dependencies (territories, overseas regions, etc.) in scope.
 
-        Scope narrows with chain depth, matching the other listing
-        methods. ``wkls.dependencies()`` at root lists every dependency
-        in the dataset; at any other depth, results are filtered to
-        dependencies within the current country chain. A dependency
-        chain (e.g. ``wkls.pr``) returns itself.
+        Scope narrows with the current Wkl's mode:
+
+        - **Root** (``wkls.dependencies()``): every dependency worldwide.
+        - **Chain-mode** (``wkls.us.dependencies()``): dependencies
+          within the current country chain (empty for country chains
+          like US; ``[self]`` on a dependency chain like PR).
+        - **Result-mode** (chained after ``.search(...)`` etc.): the
+          subset of the prior rows whose subtype is ``'dependency'``.
 
         Returns:
             A result-mode ``Wkl`` wrapping the matching rows.
@@ -1517,11 +1530,13 @@ class Wkl:
     def countries(self) -> Wkl:
         """List countries in scope.
 
-        Scope narrows with chain depth, matching the other listing
-        methods. ``wkls.countries()`` at root lists every country in
-        the dataset; at any other depth, the result is the one country
-        that contains the current chain (``wkls.us.countries()`` →
-        ``[US]``).
+        Scope narrows with the current Wkl's mode:
+
+        - **Root** (``wkls.countries()``): every country worldwide.
+        - **Chain-mode** (``wkls.us.countries()``): the one country
+          that contains the current chain.
+        - **Result-mode** (chained after ``.search(...)`` etc.): the
+          subset of the prior rows whose subtype is ``'country'``.
 
         Returns:
             A result-mode ``Wkl`` wrapping the matching rows.
@@ -1531,11 +1546,19 @@ class Wkl:
     def _list_top_level_subtype(self, subtype: str) -> Wkl:
         """Shared implementation for ``countries()`` / ``dependencies()``.
 
-        Both list a top-level subtype. At root, return every row of that
-        subtype. On any chain, filter by the current country so the
-        result is bound to the chain's scope (one row for the
-        matching country / dependency, or empty otherwise).
+        Both list a top-level subtype. Behavior by mode:
+
+        - **Result-mode** (empty chain, cached DataFrame): filter the
+          prior rows to those with the requested subtype.
+        - **Root** (empty chain, no DataFrame): every row of that
+          subtype worldwide.
+        - **Chain-mode**: filter by the current country so the result
+          is bound to the chain's scope (one row for the matching
+          country / dependency, or empty otherwise).
         """
+        if not self.chain and self._df is not None:
+            return self._narrow_result_mode_by_subtypes(f"('{subtype}')")
+
         if not self.chain:
             query = f"""
                 SELECT DISTINCT id, country, subtype, name_primary, name_en
@@ -1567,8 +1590,39 @@ class Wkl:
         """
         return self._list_subtype("('region')", "regions")
 
+    def _narrow_result_mode_by_subtypes(self, subtype_filter: str) -> Wkl:
+        """Filter a result-mode ``Wkl``'s cached DataFrame by subtype.
+
+        Shared helper for ``countries()`` / ``dependencies()`` /
+        ``regions()`` / ``counties()`` / ``cities()`` to implement
+        the "listing method narrows within the prior result" behavior
+        uniformly. Callers must ensure they're in result-mode (empty
+        chain, ``_df`` set) before invoking.
+
+        Args:
+            subtype_filter: SQL subtype filter in IN-list form,
+                e.g. ``"('county')"`` or ``"('locality', 'localadmin')"``.
+
+        Returns:
+            A result-mode ``Wkl`` wrapping the filtered rows.
+        """
+        assert self._df is not None and not self.chain
+        self._df.to_view("_wkls_list_within", overwrite=True)
+        sql = f"SELECT * FROM _wkls_list_within WHERE subtype IN {subtype_filter}"
+        return Wkl(_df=sedona.sql(sql))
+
     def _list_subtype(self, subtype_filter: str, method_name: str) -> Wkl:
-        """List rows of the given subtype within the current chain scope.
+        """List rows of the given subtype within the current scope.
+
+        Scope is determined by the current Wkl's mode:
+
+        - **Result-mode** (empty chain, cached DataFrame): filter the
+          prior rows. Lets callers chain, e.g.
+          ``wkls.us.search('san').counties()``.
+        - **Root** (empty chain, no DataFrame): every row of the
+          requested subtype worldwide.
+        - **Chain-mode**: scoped by country (depth 1) / region
+          (depth 2), or by parent_id + self (depth ≥ 3).
 
         Args:
             subtype_filter: SQL subtype filter, e.g. ``"('county')"`` or
@@ -1582,6 +1636,11 @@ class Wkl:
             ValueError: If called on a chain that resolves to more than
                 one row past region level (can't scope by a single parent).
         """
+        # Result-mode: narrow within the cached DataFrame. Shared with
+        # countries/dependencies/subtypes via _narrow_result_mode_by_subtypes.
+        if not self.chain and self._df is not None:
+            return self._narrow_result_mode_by_subtypes(subtype_filter)
+
         depth = len(self.chain)
 
         if depth == 0:
@@ -1674,20 +1733,25 @@ class Wkl:
     def subtypes(self) -> Wkl:
         """List distinct division subtypes in scope.
 
-        Scope narrows with chain depth, matching the other listing
-        methods. ``wkls.subtypes()`` at root enumerates every subtype
-        in the dataset; at a country or region chain, the result is
-        restricted to subtypes present within that scope (e.g.
-        ``wkls.fk.subtypes()`` shows the Falklands lack regions).
+        Scope is determined by the current Wkl's mode:
 
-        Returns:
-            A result-mode ``Wkl`` wrapping the distinct subtype rows.
+        - **Root** (``wkls.subtypes()``): every subtype in the dataset.
+        - **Chain-mode** (``wkls.us.subtypes()`` / ``wkls.us.ca.subtypes()``):
+          subtypes present within that chain's subtree (e.g.
+          ``wkls.fk.subtypes()`` shows the Falklands lack regions).
+        - **Result-mode** (chained after ``.search(...)`` etc.):
+          distinct subtypes present in the prior rows.
 
         Raises:
             ValueError: If the chain resolves to more than one row past
                 region level (same single-row requirement as
                 ``counties()`` / ``cities()``).
         """
+        # Result-mode: narrow within the cached DataFrame.
+        if not self.chain and self._df is not None:
+            self._df.to_view("_wkls_list_within", overwrite=True)
+            return Wkl(_df=sedona.sql("SELECT DISTINCT subtype FROM _wkls_list_within"))
+
         depth = len(self.chain)
 
         if depth == 0:

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -241,6 +241,16 @@ SEARCH_REGION = f"""
     ORDER BY COALESCE(name_en, name_primary) ASC
 """
 
+# Narrowing search on a result-mode Wkl: filter rows in an already-
+# resolved DataFrame (registered as a temp view) by the same
+# normalized name match. Lets callers chain ``.search()`` calls to
+# progressively narrow results.
+SEARCH_WITHIN_VIEW = f"""
+    SELECT * FROM {{view_name}}
+    WHERE {_SEARCH_NAME_MATCH}
+    ORDER BY COALESCE(name_en, name_primary) ASC
+"""
+
 # For city-level suggestions (Levenshtein fuzzy matching)
 # Use {region_filter} = "AND region = '{region}'" or "" for countries without regions
 SUGGEST_CITY = f"""


### PR DESCRIPTION
## Summary
Every scoped method — ``.search()``, ``.countries()``, ``.dependencies()``, ``.regions()``, ``.counties()``, ``.cities()``, ``.subtypes()`` — had the same bug: called on a result-mode ``Wkl`` (empty chain, cached DataFrame), they fired a fresh global query instead of filtering within the prior rows. One rule now applies uniformly: **on result-mode, filter within the prior rows.**

## Before / after

```python
>>> wkls.us.ca.search('san').search('san francisco').count()
# before: 148 rows from GT, CO, PY, EC, AR, BO, MX, VE, ...
# after:    2  (San Francisco + South San Francisco, both US/CA)

>>> wkls.search('franklin').counties().count()
# before: 38840  (every county in the world)
# after:       0  (no 'franklin' row is a county)

>>> wkls.us.search('san').cities().count()
# before: 588649 (every city in the world)
# after:     329 (locality/localadmin rows in the prior 'san' result)

>>> wkls.search('united').countries().count()
# before: 219
# after: N  (just the country rows matching 'united')
```

## Implementation
- Shared helper ``_narrow_result_mode_by_subtypes()`` handles the filter uniformly for countries / dependencies / regions / counties / cities.
- ``_list_subtype`` checks for result-mode first; ``countries()`` and ``dependencies()`` call the helper directly.
- ``subtypes()`` uses the same shape but projects ``DISTINCT subtype`` since its output is a column enumeration.
- ``.search()`` keeps its dedicated ``SEARCH_WITHIN_VIEW`` path (filter by name, not by subtype).
- Access control: ``__getattribute__`` gate relaxed — listing methods (``countries`` / ``dependencies`` / ``subtypes``) pass through on result-mode; config methods (``configure`` / ``overture_version`` / ``overture_releases``) stay strictly hidden. ``_LISTING_ROOT_METHODS`` names the allowlist.

## Test plan
- [ ] CI — full suite (141 passed, 2 xfailed locally)
- [ ] ``wkls.us.ca.search('san').search('san francisco')`` stays in US/CA
- [ ] ``wkls.search('franklin').counties()`` narrows to the prior rows
- [ ] ``wkls.us.search('san').cities()`` returns only locality/localadmin
- [ ] ``wkls.search('san').subtypes()`` returns only subtypes present in the prior rows
- [ ] ``hasattr(wkls.search('san'), 'configure')`` is False (config stays root-only)