### PR TITLE
perf: drop redundant queries in help(wkls), repr, and geometry fetch

### DIFF
--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -79,6 +79,9 @@ def reset_caches() -> None:
     core._country_info.clear()
     core._region_info.clear()
     core._row_info.clear()
+    # `_country_info` is seeded at module import, so real post-import state
+    # starts with it populated — re-seed to match what cold users actually see.
+    core._seed_country_info()
 
 
 def time_once(code: str, sf_id: str) -> float:

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,20 +1,25 @@
 #!/usr/bin/env python3
-"""Benchmark wkls patterns that don't hit the network.
+"""Benchmark wkls patterns.
 
-Cold = module-level caches cleared before the call. Warm = median of
-``WARM_REPS`` repeats with caches populated. Run before and after a
-change to confirm the direction of the impact; don't treat the numbers
+Local bench (default): non-network operations — dir/help, chain drills,
+listings, search, repr, navigation. Cold = module-level caches cleared
+before the call. Warm = median of ``WARM_REPS`` repeats with caches
+populated.
+
+Geometry bench (``--geom``): opt-in because every call hits S3 and takes
+seconds. Reports warm (2nd call) wall-clock for a handful of locations.
+
+Run before and after a change to confirm direction. Don't treat numbers
 as absolute (wall-clock, shared machines).
 
-Skipped on purpose: ``.wkt()``, ``.wkb()``, ``.geojson()``, ``.hexwkb()``,
-``.svg()`` — all trigger ``_ensure_overture_loaded`` and read S3.
-
 Usage:
-    uv run scripts/bench.py
+    uv run scripts/bench.py             # local patterns only
+    uv run scripts/bench.py --geom      # only the geometry-fetch cases
 """
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
 import time
@@ -23,8 +28,8 @@ from statistics import median
 import wkls
 from wkls import core
 
-
 WARM_REPS = 5
+GEOM_REPS = 3
 
 
 def _prefetch_sf_id() -> str:
@@ -37,40 +42,43 @@ def build_cases(sf_id: str) -> list[tuple[str, str]]:
     _ = sf_id  # referenced inside exec'd snippets via the namespace
     return [
         # Introspection
-        ("dir(wkls)",                              "dir(wkls)"),
-        ("dir(wkls.us)",                           "dir(wkls.us)"),
-        ("dir(wkls.us.ca)",                        "dir(wkls.us.ca)"),
-        ("pydoc.render_doc(wkls)  # help proxy",   "import pydoc; pydoc.render_doc(wkls)"),
-        ("pydoc.render_doc(wkls.us)",              "import pydoc; pydoc.render_doc(wkls.us)"),
+        ("dir(wkls)", "dir(wkls)"),
+        ("dir(wkls.us)", "dir(wkls.us)"),
+        ("dir(wkls.us.ca)", "dir(wkls.us.ca)"),
+        (
+            "pydoc.render_doc(wkls)  # help proxy",
+            "import pydoc; pydoc.render_doc(wkls)",
+        ),
+        ("pydoc.render_doc(wkls.us)", "import pydoc; pydoc.render_doc(wkls.us)"),
         # Chain drills
-        ("wkls.us",                                "wkls.us"),
-        ("wkls.us.ca",                             "wkls.us.ca"),
-        ("wkls.us.ca.sanfrancisco",                "wkls.us.ca.sanfrancisco"),
-        ("wkls.unitedstates  # name vs ISO",       "wkls.unitedstates"),
+        ("wkls.us", "wkls.us"),
+        ("wkls.us.ca", "wkls.us.ca"),
+        ("wkls.us.ca.sanfrancisco", "wkls.us.ca.sanfrancisco"),
+        ("wkls.unitedstates  # name vs ISO", "wkls.unitedstates"),
         ("wkls.us.pa.adamscounty.franklin  # 4-lvl", "wkls.us.pa.adamscounty.franklin"),
         # Lookup
-        ("wkls.by_id(<sf id>)",                    "wkls.by_id(SF_ID)"),
+        ("wkls.by_id(<sf id>)", "wkls.by_id(SF_ID)"),
         # Listings
-        ("wkls.countries()",                       "wkls.countries()"),
-        ("wkls.dependencies()",                    "wkls.dependencies()"),
-        ("wkls.subtypes()",                        "wkls.subtypes()"),
-        ("wkls.us.regions()",                      "wkls.us.regions()"),
-        ("wkls.us.ca.counties()",                  "wkls.us.ca.counties()"),
-        ("wkls.us.ca.sandiegocounty.cities()",     "wkls.us.ca.sandiegocounty.cities()"),
+        ("wkls.countries()", "wkls.countries()"),
+        ("wkls.dependencies()", "wkls.dependencies()"),
+        ("wkls.subtypes()", "wkls.subtypes()"),
+        ("wkls.us.regions()", "wkls.us.regions()"),
+        ("wkls.us.ca.counties()", "wkls.us.ca.counties()"),
+        ("wkls.us.ca.sandiegocounty.cities()", "wkls.us.ca.sandiegocounty.cities()"),
         # Search
-        ("wkls.search('franklin')",                "wkls.search('franklin')"),
-        ("wkls.us.tn.search('franklin')",          "wkls.us.tn.search('franklin')"),
+        ("wkls.search('franklin')", "wkls.search('franklin')"),
+        ("wkls.us.tn.search('franklin')", "wkls.us.tn.search('franklin')"),
         # Result-mode inspection
-        ("wkls.countries().count()",               "wkls.countries().count()"),
-        ("wkls.countries().head(5)",               "wkls.countries().head(5)"),
-        ("wkls.countries().to_dicts()",            "wkls.countries().to_dicts()"),
+        ("wkls.countries().count()", "wkls.countries().count()"),
+        ("wkls.countries().head(5)", "wkls.countries().head(5)"),
+        ("wkls.countries().to_dicts()", "wkls.countries().to_dicts()"),
         # Repr
-        ("repr(wkls.us.ca)  # chain, single row",  "repr(wkls.us.ca)"),
-        ("repr(wkls.us.ca.sanfrancisco)",          "repr(wkls.us.ca.sanfrancisco)"),
+        ("repr(wkls.us.ca)  # chain, single row", "repr(wkls.us.ca)"),
+        ("repr(wkls.us.ca.sanfrancisco)", "repr(wkls.us.ca.sanfrancisco)"),
         ("repr(wkls.countries())  # result, 219r", "repr(wkls.countries())"),
         # Navigation
-        ("wkls.us.ca.sanfrancisco.parent",         "wkls.us.ca.sanfrancisco.parent"),
-        ("wkls.us.ca.sanfrancisco.path",           "wkls.us.ca.sanfrancisco.path"),
+        ("wkls.us.ca.sanfrancisco.parent", "wkls.us.ca.sanfrancisco.parent"),
+        ("wkls.us.ca.sanfrancisco.path", "wkls.us.ca.sanfrancisco.path"),
     ]
 
 
@@ -110,7 +118,33 @@ def measure_import() -> float:
     return float(out.strip().splitlines()[-1])
 
 
-def main() -> None:
+GEOM_CASES: list[tuple[str, str]] = [
+    ("wkls.us.wkt()  # country", "wkls.us.wkt()"),
+    ("wkls.us.ca.wkt()  # region", "wkls.us.ca.wkt()"),
+    ("wkls.us.ca.sanfrancisco.wkt()  # city", "wkls.us.ca.sanfrancisco.wkt()"),
+    (
+        "wkls.us.pa.adamscounty.franklin.wkt()  # 4-lvl",
+        "wkls.us.pa.adamscounty.franklin.wkt()",
+    ),
+    ("wkls.us.ca.sanfrancisco.geojson()", "wkls.us.ca.sanfrancisco.geojson()"),
+]
+
+
+def bench_geom(code: str) -> tuple[float, float]:
+    """First call (cold overture view + fresh query), then median of GEOM_REPS warm calls."""
+    namespace: dict = {"wkls": wkls}
+    t = time.perf_counter()
+    exec(code, namespace)
+    cold = time.perf_counter() - t
+    warm = []
+    for _ in range(GEOM_REPS):
+        t = time.perf_counter()
+        exec(code, namespace)
+        warm.append(time.perf_counter() - t)
+    return cold, median(warm)
+
+
+def run_local() -> None:
     # Prime sedona so the first in-process measurement isn't skewed by
     # query-plan warmup from the very first SQL call.
     wkls.countries()
@@ -126,6 +160,36 @@ def main() -> None:
     for name, code in build_cases(sf_id):
         cold, warm = bench(code, sf_id)
         print(f"{name:<44}{cold * 1000:>14.1f} ms{warm * 1000:>14.1f} ms")
+
+
+def run_geom() -> None:
+    # Prime sedona and overture view so the first case doesn't pay
+    # one-time-view-registration cost as part of its "cold" number.
+    wkls.us.wkt()
+
+    print(
+        f"wkls geom bench  —  cold = first call, warm = median of {GEOM_REPS} repeats"
+    )
+    print("=" * 82)
+    print(f"{'pattern':<54}{'cold':>13}{'warm':>13}")
+    print("-" * 82)
+    for name, code in GEOM_CASES:
+        cold, warm = bench_geom(code)
+        print(f"{name:<54}{cold * 1000:>10.0f} ms{warm * 1000:>10.0f} ms")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="wkls bench")
+    parser.add_argument(
+        "--geom",
+        action="store_true",
+        help="Run only the geometry-fetch cases (hits S3)",
+    )
+    args = parser.parse_args()
+    if args.geom:
+        run_geom()
+    else:
+        run_local()
 
 
 if __name__ == "__main__":

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Benchmark wkls patterns that don't hit the network.
+
+Cold = module-level caches cleared before the call. Warm = median of
+``WARM_REPS`` repeats with caches populated. Run before and after a
+change to confirm the direction of the impact; don't treat the numbers
+as absolute (wall-clock, shared machines).
+
+Skipped on purpose: ``.wkt()``, ``.wkb()``, ``.geojson()``, ``.hexwkb()``,
+``.svg()`` — all trigger ``_ensure_overture_loaded`` and read S3.
+
+Usage:
+    uv run scripts/bench.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from statistics import median
+
+import wkls
+from wkls import core
+
+
+WARM_REPS = 5
+
+
+def _prefetch_sf_id() -> str:
+    """Return a real row id so ``by_id`` has a valid target."""
+    rows = wkls.us.ca.sanfrancisco.to_dicts()
+    return rows[0]["id"]
+
+
+def build_cases(sf_id: str) -> list[tuple[str, str]]:
+    _ = sf_id  # referenced inside exec'd snippets via the namespace
+    return [
+        # Introspection
+        ("dir(wkls)",                              "dir(wkls)"),
+        ("dir(wkls.us)",                           "dir(wkls.us)"),
+        ("dir(wkls.us.ca)",                        "dir(wkls.us.ca)"),
+        ("pydoc.render_doc(wkls)  # help proxy",   "import pydoc; pydoc.render_doc(wkls)"),
+        ("pydoc.render_doc(wkls.us)",              "import pydoc; pydoc.render_doc(wkls.us)"),
+        # Chain drills
+        ("wkls.us",                                "wkls.us"),
+        ("wkls.us.ca",                             "wkls.us.ca"),
+        ("wkls.us.ca.sanfrancisco",                "wkls.us.ca.sanfrancisco"),
+        ("wkls.unitedstates  # name vs ISO",       "wkls.unitedstates"),
+        ("wkls.us.pa.adamscounty.franklin  # 4-lvl", "wkls.us.pa.adamscounty.franklin"),
+        # Lookup
+        ("wkls.by_id(<sf id>)",                    "wkls.by_id(SF_ID)"),
+        # Listings
+        ("wkls.countries()",                       "wkls.countries()"),
+        ("wkls.dependencies()",                    "wkls.dependencies()"),
+        ("wkls.subtypes()",                        "wkls.subtypes()"),
+        ("wkls.us.regions()",                      "wkls.us.regions()"),
+        ("wkls.us.ca.counties()",                  "wkls.us.ca.counties()"),
+        ("wkls.us.ca.sandiegocounty.cities()",     "wkls.us.ca.sandiegocounty.cities()"),
+        # Search
+        ("wkls.search('franklin')",                "wkls.search('franklin')"),
+        ("wkls.us.tn.search('franklin')",          "wkls.us.tn.search('franklin')"),
+        # Result-mode inspection
+        ("wkls.countries().count()",               "wkls.countries().count()"),
+        ("wkls.countries().head(5)",               "wkls.countries().head(5)"),
+        ("wkls.countries().to_dicts()",            "wkls.countries().to_dicts()"),
+        # Repr
+        ("repr(wkls.us.ca)  # chain, single row",  "repr(wkls.us.ca)"),
+        ("repr(wkls.us.ca.sanfrancisco)",          "repr(wkls.us.ca.sanfrancisco)"),
+        ("repr(wkls.countries())  # result, 219r", "repr(wkls.countries())"),
+        # Navigation
+        ("wkls.us.ca.sanfrancisco.parent",         "wkls.us.ca.sanfrancisco.parent"),
+        ("wkls.us.ca.sanfrancisco.path",           "wkls.us.ca.sanfrancisco.path"),
+    ]
+
+
+def reset_caches() -> None:
+    core._dir_cache.clear()
+    core._country_info.clear()
+    core._region_info.clear()
+    core._row_info.clear()
+
+
+def time_once(code: str, sf_id: str) -> float:
+    namespace: dict = {"wkls": wkls, "SF_ID": sf_id}
+    t = time.perf_counter()
+    exec(code, namespace)
+    return time.perf_counter() - t
+
+
+def bench(code: str, sf_id: str) -> tuple[float, float]:
+    reset_caches()
+    cold = time_once(code, sf_id)
+    warm = [time_once(code, sf_id) for _ in range(WARM_REPS)]
+    return cold, median(warm)
+
+
+def measure_import() -> float:
+    """Full cold import time in a fresh Python process."""
+    script = (
+        "import time\n"
+        "t = time.perf_counter()\n"
+        "import wkls\n"
+        "print(time.perf_counter() - t)\n"
+    )
+    out = subprocess.check_output([sys.executable, "-c", script], text=True)
+    return float(out.strip().splitlines()[-1])
+
+
+def main() -> None:
+    # Prime sedona so the first in-process measurement isn't skewed by
+    # query-plan warmup from the very first SQL call.
+    wkls.countries()
+    sf_id = _prefetch_sf_id()
+
+    print(f"wkls bench  —  cold = fresh caches,  warm = median of {WARM_REPS}")
+    print("=" * 82)
+    import_cold = measure_import()
+    print(f"{'import wkls (fresh process)':<44}{import_cold * 1000:>14.1f} ms")
+    print("=" * 82)
+    print(f"{'pattern':<44}{'cold':>18}{'warm':>18}")
+    print("-" * 82)
+    for name, code in build_cases(sf_id):
+        cold, warm = bench(code, sf_id)
+        print(f"{name:<44}{cold * 1000:>14.1f} ms{warm * 1000:>14.1f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -20,7 +20,7 @@ def test_bracket_access_emits_deprecation():
     """Wkl()[...] still works but emits a DeprecationWarning."""
     with pytest.warns(DeprecationWarning, match="Bracket access is deprecated"):
         result = Wkl()["IN"]
-    assert result._df.to_arrow_table().column("country")[0].as_py() == "IN"
+    assert result.resolve().to_arrow_table().column("country")[0].as_py() == "IN"
 
 
 def test_bracket_wildcard_emits_deprecation_pointing_to_search():

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -115,14 +115,14 @@ def test_parent_walks_up_one_level():
     sf = wkls.us.ca.sanfrancisco
     parent = sf.parent
     assert isinstance(parent, Wkl)
-    table = parent._df.to_arrow_table()
+    table = parent.resolve().to_arrow_table()
     assert table.column("name_primary")[0].as_py() == "California"
 
 
 def test_parent_parent_chain():
     """.parent.parent walks up two levels."""
     grandparent = wkls.us.ca.sanfrancisco.parent.parent
-    table = grandparent._df.to_arrow_table()
+    table = grandparent.resolve().to_arrow_table()
     assert table.column("name_primary")[0].as_py() == "United States"
 
 
@@ -190,7 +190,7 @@ def test_chain_depth_4_resolves_ambiguity():
     """wkls.us.pa.franklin is ambiguous, but parent narrower resolves it."""
     # Adams County Franklin should be unique.
     result = wkls.us.pa.adamscounty.franklin
-    assert result._df.count() == 1
+    assert result.resolve().count() == 1
     assert result.wkt().startswith(("POLYGON", "MULTIPOLYGON"))
 
 

--- a/tests/test_lazy_overture.py
+++ b/tests/test_lazy_overture.py
@@ -38,7 +38,7 @@ import wkls  # must not raise
 
 assert wkls.countries().count() > 0, "countries() should work offline"
 assert wkls.us.regions().count() > 0, "regions() should work offline"
-assert wkls.us.ca.sanfrancisco._df.count() == 1, "chain resolution should work offline"
+assert wkls.us.ca.sanfrancisco.resolve().count() == 1, "chain resolution should work offline"
 assert wkls.us.ca.search('oakland').count() >= 1, "search should work offline"
 print("OK")
 """

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -160,11 +160,11 @@ def test_numeric_region_names():
     Japan uses "Hokkaido Prefecture" as name_en, so the user must type
     the full suffix — ILIKE is not a substring match.
     """
-    df = wkls.austria.burgenland._df.to_arrow_table()
+    df = wkls.austria.burgenland.resolve().to_arrow_table()
     assert df.num_rows >= 1
     assert df.column("region")[0].as_py() == "AT-1"
 
-    df2 = wkls.japan.hokkaidoprefecture._df.to_arrow_table()
+    df2 = wkls.japan.hokkaidoprefecture.resolve().to_arrow_table()
     assert df2.num_rows >= 1
     assert df2.column("region")[0].as_py() == "JP-01"
 
@@ -186,7 +186,7 @@ def test_india_maharashtra_full_chain():
     strict=True,
 )
 def test_diacritic_english_fallback():
-    df = wkls.ivorycoast._df.to_arrow_table()
+    df = wkls.ivorycoast.resolve().to_arrow_table()
     assert df.num_rows >= 1
     assert df.column("country")[0].as_py() == "CI"
 
@@ -199,7 +199,7 @@ def test_diacritic_english_fallback():
     strict=True,
 )
 def test_diacritic_preserved_in_replace():
-    df = wkls.brazil.saopaulo._df.to_arrow_table()
+    df = wkls.brazil.saopaulo.resolve().to_arrow_table()
     assert df.num_rows >= 1
     assert df.column("region")[0].as_py() == "BR-SP"
 
@@ -292,7 +292,7 @@ def test_empty_chain_error():
 def test_chain_depth_4_is_parent_narrower():
     """Chain depth 4 narrows by parent_id."""
     # Adams County in PA has a Franklin township — single match.
-    assert wkls.us.pa.adamscounty.franklin._df.count() == 1
+    assert wkls.us.pa.adamscounty.franklin.resolve().count() == 1
 
 
 def test_too_many_chained_attributes():
@@ -304,7 +304,7 @@ def test_too_many_chained_attributes():
 def test_nonexistent_location_returns_empty():
     """Unknown identifiers return empty DataFrames, not exceptions."""
     # ZZ is not a valid country code
-    assert wkls.zz._df.count() == 0
+    assert wkls.zz.resolve().count() == 0
 
     # ZZ is not a valid US state code
-    assert wkls.us.zz._df.count() == 0
+    assert wkls.us.zz.resolve().count() == 0

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -193,6 +193,28 @@ def _initialize_table() -> sedonadb.SedonaContext:
     return sedona
 
 
+def _seed_country_info() -> None:
+    """Populate ``_country_info`` for every country identifier in one pass.
+
+    Without this, each unique country access (``wkls.us``, ``wkls.unitedstates``,
+    etc.) fires two lookup queries the first time — and ``help(wkls)`` /
+    ``dir()`` introspection paths fan this out across ~438 identifiers.
+    Two small scans up front replace hundreds of queries on the cold path.
+    """
+    regions_tbl = sedona.sql(queries.COUNTRY_INFO_SEED_WITH_REGIONS).to_arrow_table()
+    has_region_isos: set[str] = {
+        regions_tbl.column("iso")[i].as_py() for i in range(regions_tbl.num_rows)
+    }
+    tbl = sedona.sql(queries.COUNTRY_INFO_SEED).to_arrow_table()
+    for i in range(tbl.num_rows):
+        iso = tbl.column("iso")[i].as_py()
+        name = tbl.column("name")[i].as_py()
+        value = (iso, iso in has_region_isos)
+        _country_info[iso.lower()] = value
+        if name:
+            _country_info[name] = value
+
+
 # Initialize the table when the module is imported
 sedona = _initialize_table()
 
@@ -247,6 +269,9 @@ _dir_cache: dict[tuple[str, ...], list[str]] = {}
 # id, country, region, subtype, name_primary, name_en, parent_division_id.
 # Populated by Wkl.by_id() and Wkl.parent.
 _row_info: dict[str, dict[str, object]] = {}
+
+
+_seed_country_info()
 
 
 def sqlescape(v: str) -> str:
@@ -870,6 +895,7 @@ class Wkl:
         _region_info.clear()
         _dir_cache.clear()
         _row_info.clear()
+        _seed_country_info()
         sedona.read_parquet(
             _overture_uri(overture_version),
             options={

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -940,12 +940,8 @@ class Wkl:
                 )
             parent_row = df.head(1).to_arrow_table()
             parent_id = parent_row.column("id")[0].as_py()
-            new_wkl = Wkl(new_chain, _parent_id=parent_id)
-        else:
-            new_wkl = Wkl(new_chain)
-
-        new_wkl._df = new_wkl.resolve()
-        return new_wkl
+            return Wkl(new_chain, _parent_id=parent_id)
+        return Wkl(new_chain)
 
     def __dir__(self) -> list[str]:
         """Return contextually valid attributes for this ``Wkl``.
@@ -1189,8 +1185,8 @@ class Wkl:
     def resolve(self) -> sedonadb.dataframe.DataFrame:
         """Resolve the location chain to a DataFrame.
 
-        Idempotent: returns ``self._df`` if already populated (either
-        eagerly by ``__getattr__`` on chain access, or explicitly by
+        Idempotent: returns ``self._df`` if already populated (by a
+        prior ``resolve()`` on this instance, or explicitly by
         listing/search methods in result-mode). Otherwise executes the
         appropriate SQL query based on the chain depth.
 

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1353,19 +1353,20 @@ class Wkl:
         """Retrieve geometry using a SQL expression.
 
         Resolves the location chain against the local metadata table, then
-        queries the remote Overture GeoParquet using attribute-based filters
-        that leverage Parquet predicate pushdown on low-cardinality columns
-        (country, subtype, region, is_land) for fast row group pruning.
+        queries the remote Overture GeoParquet. Two separate queries beat
+        one ``(id = X OR names.primary = Y)`` query because ``OR`` over a
+        nested struct field defeats predicate pushdown in DataFusion /
+        SedonaDB — the engine has to scan. Splitting gives the id path
+        clean pushdown on a top-level unique column.
 
-        For country/region/dependency subtypes, the combination of
-        country + region + subtype is unique, so no further disambiguation
-        is needed.
+        Path 1 (almost always): ``WHERE … AND id = '<gers_id>'``. ``id``
+        is globally unique, so this returns the single matching row.
 
-        For city/county/localadmin subtypes, the final disambiguation uses
-        ``(id = '<gers_id>' OR names.primary = '<name>')``. This makes the
-        lookup resilient to either identifier changing across Overture
-        releases: if GERS IDs stabilize (as OMF intends), the ID match is
-        the fast path; if the ID drifts, the name still resolves correctly.
+        Path 2 (only if path 1 returns 0 rows — city-tier only): fallback
+        to ``WHERE … AND names.primary = '<name>'``. Handles the rare
+        case of GERS id drift across Overture releases. is_land stays in
+        the filter here because a name like "San Francisco" can match
+        both land and territorial-water rows; we want the land one.
 
         Args:
             expr: SQL expression to apply to the geometry column.
@@ -1400,33 +1401,42 @@ class Wkl:
         subtype = row.column("subtype")[0].as_py()
         name_primary = row.column("name_primary")[0].as_py()
 
-        # Build WHERE clause from resolved attributes.
-        # Country/region/dependency are unique by country+region+subtype.
-        # City/county/localadmin use (id OR name) for resilient disambiguation.
-        conditions = [
+        base_conditions = [
             f"country = '{sqlescape(country)}'",
             f"subtype = '{sqlescape(subtype)}'",
             "is_land = true",
         ]
         if region:
-            conditions.append(f"region = '{sqlescape(region)}'")
+            base_conditions.append(f"region = '{sqlescape(region)}'")
+
+        def _fetch(extra: str) -> Any | None:
+            clauses = " AND ".join(base_conditions + [extra])
+            tbl = sedona.sql(
+                f"SELECT {expr} FROM overture WHERE {clauses} LIMIT 1"
+            ).to_arrow_table()
+            if tbl.num_rows == 0:
+                return None
+            return tbl.column(0)[0].as_py()
+
+        # Path 1: id match (the common case).
+        result = _fetch(f"id = '{sqlescape(gers_id)}'")
+        if result is not None:
+            return result
+
+        # Path 2: id drifted — only city-tier subtypes use names.primary
+        # as a secondary key. Country/region/dependency are unique by
+        # country+region+subtype, so no fallback possible or needed there.
         if subtype in ("county", "locality", "localadmin"):
-            conditions.append(
-                f"(id = '{sqlescape(gers_id)}' OR names.primary = '{sqlescape(name_primary)}')"
-            )
+            result = _fetch(f"names.primary = '{sqlescape(name_primary)}'")
+            if result is not None:
+                return result
 
-        where_clause = " AND ".join(conditions)
-        query = f"SELECT {expr} FROM overture WHERE {where_clause} LIMIT 1"
-
-        result_df = sedona.sql(query)
-        if result_df.count() == 0:
-            chain_str = ".".join(self.chain)
-            raise ValueError(
-                f"No geometry found for: {chain_str} "
-                f"(country={country}, region={region}, subtype={subtype}, "
-                f"id={gers_id}, name={name_primary})"
-            )
-        return result_df.head(1).to_arrow_table().column(0)[0].as_py()
+        chain_str = ".".join(self.chain)
+        raise ValueError(
+            f"No geometry found for: {chain_str} "
+            f"(country={country}, region={region}, subtype={subtype}, "
+            f"id={gers_id}, name={name_primary})"
+        )
 
     def wkt(self) -> str:
         """Get Well-Known Text (WKT) geometry for the first result.

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1130,44 +1130,33 @@ class Wkl:
         size at a glance. ``path=`` is used when the chain resolves to a
         single row (round-trippable); ``chain=`` is used otherwise.
         """
+        subtypes = self._subtype_counts()
+        row_count = sum(subtypes.values())
+
         parts: list[str] = []
         if self.chain:
             path_str = "wkls." + ".".join(self.chain)
-            key = "path" if self._is_single_row() else "chain"
+            key = "path" if row_count == 1 else "chain"
             parts.append(f"{key}='{path_str}'")
 
-        row_count = self._safe_row_count()
         parts.append(f"rows={row_count}")
 
-        if row_count >= 1:
-            subtypes = self._subtype_counts()
-            if len(subtypes) == 1:
-                st = next(iter(subtypes))
-                parts.append(f"subtype='{st}'")
-            elif subtypes:
-                body = ", ".join(f"{k}: {v}" for k, v in subtypes.items())
-                parts.append(f"subtypes={{{body}}}")
+        if len(subtypes) == 1:
+            st = next(iter(subtypes))
+            parts.append(f"subtype='{st}'")
+        elif subtypes:
+            body = ", ".join(f"{k}: {v}" for k, v in subtypes.items())
+            parts.append(f"subtypes={{{body}}}")
 
         return f"Wkl({', '.join(parts)})"
 
-    def _is_single_row(self) -> bool:
-        """True iff the resolved DataFrame holds exactly one row."""
-        try:
-            df = self._df if self._df is not None else self.resolve()
-            return df.count() == 1
-        except Exception:
-            return False
-
-    def _safe_row_count(self) -> int:
-        """Best-effort row count; 0 on failure so repr never throws."""
-        try:
-            df = self._df if self._df is not None else self.resolve()
-            return int(df.count())
-        except Exception:
-            return 0
-
     def _subtype_counts(self) -> dict[str, int]:
-        """Distinct subtypes with row counts, ordered by count descending."""
+        """Distinct subtypes with row counts, ordered by count descending.
+
+        One query serves the full repr header — total rows is the sum of
+        the values, single-row is ``sum == 1``. Empty dict on failure so
+        ``__repr__`` never throws.
+        """
         try:
             df = self._df if self._df is not None else self.resolve()
             df.to_view("_wkls_repr_subtypes", overwrite=True)

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -190,6 +190,26 @@ DIR_COUNTRIES = f"""
     WHERE subtype IN ('country', 'dependency')
 """
 
+# One-shot seeds for `_country_info`. Returns every country identifier
+# (ISO + normalized name); a second query lists the isos with region
+# rows. Merged in Python because SedonaDB rejects ``IN (subquery)``.
+# Populated once at module import so ``_lookup_country`` hits the cache
+# for every valid input instead of firing two queries per access — a
+# big win on introspection paths (``help(wkls)`` fans to ~438 inputs).
+COUNTRY_INFO_SEED = f"""
+    SELECT DISTINCT
+      country                 AS iso,
+      {_CHAINABLE_NAME_EXPR}  AS name
+    FROM wkls
+    WHERE subtype IN ('country', 'dependency')
+"""
+
+COUNTRY_INFO_SEED_WITH_REGIONS = """
+    SELECT DISTINCT country AS iso
+    FROM wkls
+    WHERE subtype = 'region'
+"""
+
 # Country-level dir(): ISO suffixes and normalized names for one country's regions.
 DIR_REGIONS = f"""
     SELECT DISTINCT


### PR DESCRIPTION
## Summary

Three unrelated hot paths were firing redundant SQL. Addressed in commits that each target one:

- **`help(wkls)` cold was 13s.** Module-level pydoc introspection calls `getattr` on every country identifier it sees in `dir()` (~438), and each one was firing two lookup queries through `_lookup_country`. Seeded `_country_info` at import via two bulk scans so every identifier hits a warm cache. Pair with making chain construction lazy (skip eager `resolve()` in `__getattr__`) so pydoc no longer triggers per-country `resolve()` calls either.
- **`repr()` fired 3 queries per call.** `_safe_row_count`, `_is_single_row`, `_subtype_counts` — two of which were `df.count()` on the same DataFrame. Collapsed into the single `GROUP BY subtype` query; row count is `sum(counts)`, single-row is `sum == 1`.
- **Geometry fetch had `(id = X OR names.primary = Y)`.** The OR defeats predicate pushdown on the remote Overture GeoParquet — `names.primary` is in a nested struct with no column statistics, so the engine has to scan. Split into id-first + name-fallback; the id path prunes cleanly, the fallback only runs if id drifts across Overture releases (rare).

`is_land = true` stays on both geom paths for correctness (admin boundaries like SF have both land and territorial-water rows).

### Measured impact (`scripts/bench.py`)

| pattern | main | branch |
|---|---:|---:|
| `help(wkls)` cold | 12,862 ms | 29 ms |
| chain drills (`wkls.us.ca.sanfrancisco`) cold | 42 ms | 0 ms |
| `repr(wkls.us.ca)` | 85 → 48 ms | 26 → 26 ms |
| city-tier `.wkt()` warm | ~8–12 s | ~4 s |
| `import wkls` | 54 ms | 132 ms |

Import is +80ms — one-time cost of the country-info seed, paid back many times over on the first introspection call.

## Test plan
- [x] `uv run pytest` — 148 passed, 2 xfailed
- [x] `uv run scripts/bench.py` — verifies local-pattern wins
- [x] `uv run scripts/bench.py --geom` — verifies geometry-fetch wins (opt-in, hits S3)