### PR TITLE
feat: unblock agent workflow — pager-free help + subtype narrowing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ wheels/
 
 # Virtual environments
 .venv
+.venv-*
 venv/
 ENV/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,17 @@ dev = [
 [tool.setuptools.package-data]
 wkls = ["data/overture.zstd18.parquet", "py.typed"]
 
+# Explicit sdist excludes so stray local artefacts (virtualenvs, notebooks)
+# can't end up in the tarball via non-VCS packaging paths — belt-and-
+# suspenders against .gitignore drift.
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/.venv",
+    "/.venv-*",
+    "/test_nb.ipynb",
+    "/docs",
+]
+
 [tool.ruff]
 target-version = "py39"
 line-length = 88

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -80,6 +80,41 @@ def test_search_wkt_raises_on_multi_row():
         wkls.search("united").wkt()
 
 
+def test_ambiguity_error_suggests_subtype_narrowing_when_subtypes_differ():
+    """When candidates span subtypes (e.g. city + county), the error
+    surfaces ``.cities()`` / ``.counties()`` as a narrower alongside
+    ``by_id``. This is the path an agent hits after searching for a
+    name that's both a locality and a county.
+    """
+    # San Diego in CA: the city (locality) + the county (county).
+    try:
+        wkls.us.ca.search("san diego").wkt()
+    except AmbiguousLocationError as e:
+        msg = str(e)
+    else:
+        pytest.fail("expected AmbiguousLocationError")
+    assert "filter by subtype on this result" in msg
+    assert ".cities()" in msg
+    assert ".counties()" in msg
+    # by_id still advertised as the universal escape hatch.
+    assert "wkls.by_id('" in msg
+
+
+def test_ambiguity_error_skips_subtype_narrowing_when_all_same_subtype():
+    """Subtype suggestion is suppressed when it wouldn't reduce the set.
+
+    The 18 Franklins in PA are all localities — ``.cities()`` would
+    return the same 18 rows, so the message shouldn't pretend it helps.
+    """
+    try:
+        wkls.us.pa.franklin.wkt()
+    except AmbiguousLocationError as e:
+        msg = str(e)
+    else:
+        pytest.fail("expected AmbiguousLocationError")
+    assert "filter by subtype on this result" not in msg
+
+
 # ---------- Wkl.by_id ----------
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -27,6 +27,24 @@ def test_dir_root_contains_key_attrs():
     entries = dir(wkls)
     assert "Wkl" in entries
     assert "__version__" in entries
+    # Pager-free guide entry point — must be discoverable via dir() so
+    # agents find it without reading the module source.
+    assert "help" in entries
+
+
+def test_wkls_help_prints_guide_without_pager(capsys):
+    """wkls.help() prints the module docstring to stdout.
+
+    Agents running `python -c "import wkls; help(wkls)"` get stuck on
+    the terminal pager. wkls.help() is the non-interactive equivalent
+    and should exercise a plain ``print(__doc__)`` path.
+    """
+    wkls.help()
+    out = capsys.readouterr().out
+    assert "Quickstart:" in out
+    assert "wkls.us.ca.sanfrancisco.wkt()" in out
+    # A clue that users can find the pager-free path.
+    assert "wkls.help()" in out or "print(wkls.__doc__)" in out
 
 
 def test_return_types_uniform():
@@ -102,17 +120,29 @@ def test_dir_country_level_has_path_but_not_parent():
     assert "parent" not in entries
 
 
-def test_dir_result_mode_multi_row_exposes_inspection_verbs_only():
-    """dir() on an ambiguous result shows DataFrame inspection verbs only.
+def test_dir_result_mode_multi_row_exposes_inspection_and_subtype_narrowers():
+    """dir() on an ambiguous result shows DataFrame inspection verbs plus
+    the listing methods that narrow by subtype.
 
-    Dot access is admin-hierarchy; there are no in-place filters to
-    advertise. Geometry methods are omitted because they'd raise on
-    multi-row.
+    Geometry methods stay omitted because they'd raise on multi-row. Raw
+    subtype names (``country``, ``locality``, …) are *not* advertised —
+    the narrower is the method (``cities``, ``counties``, …), not the
+    subtype attribute.
     """
     entries = set(dir(wkls.us.ca.search("san francisco")))
     assert {"count", "head", "to_arrow_table", "to_dicts"}.issubset(entries)
     assert entries.isdisjoint({"wkt", "wkb", "geojson"})  # geometry would raise
-    # No subtype narrowers — those were removed.
+    # Listing narrowers ARE advertised — they're the discovery path for
+    # agents hitting AmbiguousLocationError in result-mode.
+    assert {
+        "cities",
+        "counties",
+        "countries",
+        "dependencies",
+        "regions",
+        "subtypes",
+    }.issubset(entries)
+    # Raw subtype names are not — dot-access does not accept them as filters.
     for subtype in (
         "country",
         "dependency",

--- a/wkls/__init__.py
+++ b/wkls/__init__.py
@@ -6,6 +6,10 @@ Quickstart:
     >>> wkls.us.ca.sanfrancisco.wkt()      # geometry as WKT string
     >>> wkls.india.maharashtra.geojson()   # or GeoJSON, or wkb()
 
+In scripts and agent shells, call ``wkls.help()`` (or
+``print(wkls.__doc__)``) to read this guide. The builtin ``help(wkls)``
+opens a terminal pager that can't be driven non-interactively.
+
 Chain depth maps to the admin hierarchy (max 3 for unambiguous cases):
 
     wkls.<country>                         # country / dependency
@@ -17,11 +21,11 @@ too: wkls.us, wkls.unitedstates, wkls.us.ca, wkls.us.california.
 
 Resolving ambiguity — when a chain resolves to >1 row, geometry
 methods raise AmbiguousLocationError (a ValueError subclass) with a
-list of candidates and copy-paste-ready chains. Dot access is strictly
-admin-hierarchy — one way to narrow is via the chain, one escape hatch:
+list of candidates and copy-paste-ready code. Three ways to narrow:
 
-    wkls.us.pa.adamscounty.franklin        # (a) 4-level parent narrower
-    wkls.by_id('273bc9a0-...')             # (b) exact pick (UUID from the error)
+    wkls.us.ca.search('san diego').cities()  # (a) filter by subtype on a result
+    wkls.us.pa.adamscounty.franklin          # (b) 4-level parent narrower
+    wkls.by_id('273bc9a0-...')               # (c) exact pick (UUID from the error)
 
 When an *intermediate* chain step is ambiguous (e.g. 'york' in PA is
 both a locality and a county), pick the unambiguous full normalized
@@ -77,6 +81,20 @@ from .core import Wkl
 
 __all__ = ["Wkl"]
 
+
+# Intentionally shadows the builtin at module level so ``wkls.help()``
+# just works; deliberately omitted from ``__all__`` so ``from wkls import *``
+# does not pollute the caller's namespace with an alternate ``help``.
+def help() -> None:  # noqa: A001
+    """Print the wkls guide to stdout without opening the terminal pager.
+
+    Equivalent to ``print(wkls.__doc__)``. Use this from scripts and
+    agent shells — the builtin ``help(wkls)`` opens a pager that hangs
+    non-interactive drivers.
+    """
+    print(__doc__)
+
+
 try:
     __version__ = version("wkls")
 except PackageNotFoundError:
@@ -112,7 +130,7 @@ def __getattr__(name: str) -> Any:
 
 
 def __dir__() -> list[str]:
-    module_attrs = list(__all__) + ["__version__"]
+    module_attrs = list(__all__) + ["__version__", "help"]
     try:
         wkl_attrs = dir(_get_instance())
     except Exception:

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -339,6 +339,14 @@ _DIR_DATAFRAME_METHODS = frozenset(
     {"count", "head", "limit", "show", "to_arrow_table", "to_dicts"}
 )
 
+# Listing methods that narrow a multi-row result to a single subtype
+# (or inspect what subtypes are present). Surfaced via ``dir()`` on a
+# multi-row result-mode ``Wkl`` so agents discover the subtype-filter
+# path instead of falling straight to ``by_id`` when ``.wkt()`` raises.
+_DIR_RESULT_NARROW_METHODS = frozenset(
+    {"cities", "counties", "countries", "dependencies", "regions", "subtypes"}
+)
+
 
 def _normalize_name(name: str | None) -> str:
     """Lowercase + strip non-alphanumerics. Matches ``__getattr__`` input form."""
@@ -596,8 +604,10 @@ class Wkl:
         #   2. Candidates share a normalized name but have different
         #      parents (e.g. 18 Franklins in PA counties) — use the
         #      4-level parent narrower.
-        # Anything else (same name + same parent, or no chain context)
-        # can only be resolved by picking a specific UUID.
+        # A third narrower applies when candidates span multiple
+        # subtypes (e.g. a search result with both a city and a
+        # county): call the subtype method on the result.
+        # Anything else can only be resolved by picking a specific UUID.
         attrs_differ = len({c["attr"] for c in candidates}) > 1
         parents_differ = len({c["parent_attr"] for c in candidates}) > 1
 
@@ -635,6 +645,30 @@ class Wkl:
                 "distinguishes these — use by_id:"
             )
             lines.append("")
+
+        # Subtype narrowing — applies whenever candidates span multiple
+        # subtype *groups* (two rows both in ``locality`` don't get a
+        # suggestion since ``.cities()`` wouldn't reduce anything). Shown
+        # alongside the primary narrower, before ``by_id``.
+        _METHOD_FOR_SUBTYPE = {
+            "country": "countries",
+            "dependency": "dependencies",
+            "region": "regions",
+            "county": "counties",
+            "locality": "cities",
+            "localadmin": "cities",
+        }
+        by_method: dict[str, list[str]] = {}
+        for c in candidates:
+            method = _METHOD_FOR_SUBTYPE.get(c["subtype"])
+            if method:
+                by_method.setdefault(method, []).append(c["subtype"])
+        if len(by_method) > 1:
+            lines.append("")
+            lines.append("Or filter by subtype on this result:")
+            for method, subtypes in by_method.items():
+                label = "/".join(sorted(set(subtypes)))
+                lines.append(f"  .{method}()  # {len(subtypes)} {label} row(s)")
 
         # Always show by_id lines with literal UUID + .wkt() call so agents
         # can copy-paste directly.
@@ -1009,7 +1043,7 @@ class Wkl:
         """Return the attribute surface valid for the current result set.
 
         Branches on row count: geometry + navigation for single-row,
-        subtype modifiers for multi-row, DataFrame verbs for empty.
+        listing narrowers for multi-row, DataFrame verbs for empty.
         See ``__dir__`` for the full contract.
         """
         assert self._df is not None
@@ -1019,10 +1053,10 @@ class Wkl:
             return base
         if row_count == 1:
             return base | _DIR_CITY_METHODS
-        # Multi-row: only the DataFrame inspection verbs. Dot access
-        # is admin-hierarchy only — there's no in-place subtype filter,
-        # so nothing else belongs in the surface here.
-        return base
+        # Multi-row: surface the subtype-filter methods alongside the
+        # DataFrame verbs so agents can discover the narrow-by-subtype
+        # path (e.g. ``search(...).cities()``) without reading docs.
+        return base | _DIR_RESULT_NARROW_METHODS
 
     def _dir_countries(self) -> list[str]:
         """Return cached country-level dir entries (ISO codes + names)."""


### PR DESCRIPTION
## Why

From an agent session (Copilot, terminal shell, local install):

```
pip show wkls OR python3 -c "import wkls; help(wkls)" | head -50
# … pager hangs, agent sends 'q', then echo 'test', finally:
PAGER=cat MANPAGER=cat python3 -c "..."
```

Agent wasted ~8 commands escaping the terminal pager that `help(wkls)` opens. Then spent another ~10 commands on `inspect.signature` + `dir(Wkl)` to reverse-engineer the API. Finally ran `.search('san diego').wkt()`, hit `AmbiguousLocationError`, and jumped to `by_id('<uuid>')` from the error message — never discovering that `.search('san diego').cities().wkt()` is a faster path.

## What

Three changes unblock the agent workflow without rewriting anything:

1. **`wkls.help()`** — prints the module docstring to stdout. Same content as `help(wkls)` but no pager. Listed in `dir(wkls)` so agents find it. Intentionally omitted from `__all__` to avoid polluting `from wkls import *`.
2. **`AmbiguousLocationError` suggests subtype narrowers** when candidates span multiple subtypes. E.g. for San Diego (city + county), the error now emits `.cities()` / `.counties()` alongside `by_id(...)`. Suppressed when narrowing wouldn't reduce the set (e.g. all 18 Franklin townships in PA are localities — `.cities()` wouldn't help, so it isn't suggested).
3. **Multi-row result-mode `dir()`** advertises the listing methods (`cities`, `counties`, `regions`, `countries`, `dependencies`, `subtypes`). Previously only inspection verbs (`count`, `head`, etc.) showed up — so agents never saw the subtype-filter path unless they read the docstring.

Module docstring updated to lead with `wkls.help()` and list subtype narrowing as option (a) under "Resolving ambiguity".

Also includes a small unrelated build fix: broader `.venv-*` ignore + explicit hatch sdist excludes so `uv build` doesn't pick up local virtualenvs or `test_nb.ipynb`.

## Test plan
- [x] `uv run pytest` — 151 passed, 2 xfailed (added 3 tests: pager-free help, subtype suggestion fires, subtype suggestion suppressed when redundant)
- [x] Smoke-tested the suggested narrower end-to-end: `wkls.us.ca.search('san diego').cities().wkt()` returns a valid WKT
- [x] `dir(wkls)` includes `help`; `dir(wkls.us.ca.search('san diego'))` includes `cities`, `counties`, etc.
- [x] `uv build` succeeds with a 35-file sdist (no `.venv-*` / notebooks)

## Follow-ups (not in this PR)

Scoped out to keep this PR focused on the agent-trap we set out to fix. Tracked from a Copilot usability review + an ecosystem survey in `docs/investigations/llm-friendly-library-patterns.md`:

- **`.head(n)` / `.limit(n)` should return a `Wkl`, not a raw sedona DataFrame.** Agents naturally chain `.head(3).to_dicts()` and it fails because `.to_dicts()` is a `Wkl` method, not a DataFrame method. Fix is ~10 LOC — wrap the sliced DataFrame in a result-mode `Wkl`.
- **`Did you mean '<X>'?` on unknown chain attributes.** `wkls.us.ca.sanfransisco` should suggest `sanfrancisco` via `difflib.get_close_matches`. Python 3.10+ ships this for `NameError`/`AttributeError`; we'd mirror that convention for chain misses. ~20 LOC.
- **Distinguishing labels for identical-looking ambiguity candidates.** Two Yorks in York County, PA currently render as two identical lines in the error — append last-4-of-UUID (or similar) so visually distinct, even if the ultimate picker is still `by_id`.
- **Ship `docs/llms.txt`** — short index file following the Answer.AI convention (adopted by Pydantic AI, Anthropic docs, Stripe, Cloudflare). Pointers to README + per-feature markdown sections, not inline docs. Near-zero maintenance.