### PR TITLE
feat!: three-surface API for v1.2.0 (Surface 2 dunders + .to_arrow_table() escape + empty allowlist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,16 +187,6 @@ Overture retains only the 2 most recent releases on S3, so long-lived
 pins eventually become invalid. Use `overture_releases()` to check
 what's currently available.
 
-### Bracket access (removed)
-
-Bracket access (`wkls.us["ne"]`, `wkls.us.ca["%fran%"]`) was removed in
-v1.2.0 and raises `TypeError` with migration instructions:
-
-- Keyword / numeric collisions → use the English name:
-  `wkls.us.nebraska`, `wkls.austria.burgenland`.
-- Wildcard search → use `.search()`:
-  `wkls.us.ca.search("fran")`.
-
 ### Handoff to your engine (`to_arrow_table`)
 
 When you need more than admin-boundary lookup — filtering, joins,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ wkls.us.ca.sanfrancisco.wkt()
 - `.search("query")` at any chain level — scoped to the current subtree
 - Precise geometries from [Overture Maps Foundation](https://overturemaps.org/) — no bounding boxes, no shapefiles
 - Outputs boundaries in WKT, WKB, or GeoJSON
-- Support for HexWKB and SVG planned
+- Bulk export to `pyarrow.Table` with GeoArrow WKB geometry via `.to_arrow_table()`
 - Zero configuration — no API keys, no downloads, no setup
 - Automatically uses the latest Overture Maps release
 
@@ -103,7 +103,7 @@ wkls.us.ca.search("san francisco")  # anywhere in California
 ```
 
 Results come back as a `Wkl` — the same type every other access returns.
-Call `.count()`, `.head()`, `.to_arrow_table()`, or `.to_dicts()` for
+Use `len()`, `list()`, slicing, or `.to_dicts()` for
 inspection, or `.wkt()` / `.wkb()` / `.geojson()` on a single-row
 result to fetch geometry in one step. `.to_dicts()` is the easiest
 way to iterate rows in plain Python:
@@ -187,18 +187,37 @@ Overture retains only the 2 most recent releases on S3, so long-lived
 pins eventually become invalid. Use `overture_releases()` to check
 what's currently available.
 
-### Bracket access (deprecated)
+### Bracket access (removed)
 
-Bracket access (`wkls.us["ne"]`, `wkls.us.ca["%fran%"]`) still works but
-emits a `DeprecationWarning` pointing at the modern replacement:
+Bracket access (`wkls.us["ne"]`, `wkls.us.ca["%fran%"]`) was removed in
+v1.2.0 and raises `TypeError` with migration instructions:
 
 - Keyword / numeric collisions → use the English name:
   `wkls.us.nebraska`, `wkls.austria.burgenland`.
 - Wildcard search → use `.search()`:
   `wkls.us.ca.search("fran")`.
 
-Bracket access at the module root (`wkls["..."]`) is not supported — real
-Python modules aren't subscriptable. Use dot access or `Wkl()["..."]`.
+### Handoff to your engine (`to_arrow_table`)
+
+When you need more than admin-boundary lookup — filtering, joins,
+spatial analysis — escape to a `pyarrow.Table` with full geometry:
+
+```python
+tbl = wkls.us.ca.cities().to_arrow_table()
+```
+
+The table includes all metadata columns plus a `geometry` column typed
+as GeoArrow WKB with `OGC:CRS84` CRS. Hand it to any Arrow-aware engine:
+
+```python
+ctx.create_data_frame(tbl)
+```
+
+For metadata-only inspection (no geometry fetch), use `.to_dicts()`:
+
+```python
+[r for r in wkls.search("franklin").to_dicts() if r["country"] != "US"]
+```
 
 ## How it works
 

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -69,8 +69,8 @@ def build_cases(sf_id: str) -> list[tuple[str, str]]:
         ("wkls.search('franklin')", "wkls.search('franklin')"),
         ("wkls.us.tn.search('franklin')", "wkls.us.tn.search('franklin')"),
         # Result-mode inspection
-        ("wkls.countries().count()", "wkls.countries().count()"),
-        ("wkls.countries().head(5)", "wkls.countries().head(5)"),
+        ("len(wkls.countries())", "len(wkls.countries())"),
+        ("wkls.countries()[:5]", "wkls.countries()[:5]"),
         ("wkls.countries().to_dicts()", "wkls.countries().to_dicts()"),
         # Repr
         ("repr(wkls.us.ca)  # chain, single row", "repr(wkls.us.ca)"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Pytest fixtures shared across the test suite.
 
-The pre-v1.3 ``ignore_bracket_deprecation`` fixture was removed when the
-bracket-access shim was replaced with a ``TypeError`` in v1.3.0. No
+The pre-v1.2 ``ignore_bracket_deprecation`` fixture was removed when the
+bracket-access shim was replaced with a ``TypeError`` in v1.2.0. No
 module-level fixtures are currently shared; kept for future additions.
 """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,8 @@
-"""Pytest fixtures shared across the test suite."""
+"""Pytest fixtures shared across the test suite.
+
+The pre-v1.3 ``ignore_bracket_deprecation`` fixture was removed when the
+bracket-access shim was replaced with a ``TypeError`` in v1.3.0. No
+module-level fixtures are currently shared; kept for future additions.
+"""
 
 from __future__ import annotations
-
-import warnings
-
-import pytest
-
-
-@pytest.fixture
-def ignore_bracket_deprecation():
-    """Silence DeprecationWarning emitted by legacy __getitem__ calls.
-
-    Used by tests that exercise bracket access on purpose — for example,
-    regression tests asserting the shim still works, or older tests that
-    predate the `.search()` / name-access migration.
-    """
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"Bracket access.*deprecated",
-            category=DeprecationWarning,
-        )
-        yield

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,8 +1,8 @@
-"""Tests for the v1.3.0 removal of the bracket-access deprecation shim.
+"""Tests for the v1.2.0 removal of the bracket-access deprecation shim.
 
-Pre-v1.3, ``Wkl.__getitem__`` accepted string keys as a deprecated
+Pre-v1.2, ``Wkl.__getitem__`` accepted string keys as a deprecated
 alias for chain access / wildcard search and emitted a
-``DeprecationWarning``. In v1.3.0 the shim was removed — string
+``DeprecationWarning``. In v1.2.0 the shim was removed — string
 subscripts now raise ``TypeError`` pointing at the modern replacement
 (dot access, ``.search(...)``, ``.resolve()``). See
 ``docs/design/pythonic-wkl.md`` § Migration.
@@ -20,7 +20,7 @@ from wkls import Wkl
 
 
 def test_string_bracket_access_raises():
-    """``Wkl()["IN"]`` used to warn; v1.3 raises ``TypeError``."""
+    """``Wkl()["IN"]`` used to warn; v1.2 raises ``TypeError``."""
     with pytest.raises(TypeError, match="dot access"):
         Wkl()["IN"]
 
@@ -32,7 +32,7 @@ def test_string_bracket_access_message_points_at_search():
 
 
 def test_wildcard_bracket_access_raises():
-    """``wkls.us.ca["%fran%"]`` used to warn and resolve; v1.3 raises."""
+    """``wkls.us.ca["%fran%"]`` used to warn and resolve; v1.2 raises."""
     with pytest.raises(TypeError, match="dot access"):
         wkls.us.ca["%fran%"]
 
@@ -44,7 +44,7 @@ def test_chained_string_bracket_access_raises():
 
 
 def test_list_bracket_access_raises():
-    """List keys (pre-v1.3: DataFrame column selection passthrough) now raise.
+    """List keys (pre-v1.2: DataFrame column selection passthrough) now raise.
 
     Users wanting DataFrame-style column selection should call
     ``.resolve()`` and use the sedona DataFrame directly.

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,14 +1,17 @@
-"""Tests for the bracket-access deprecation shim.
+"""Tests for the v1.3.0 removal of the bracket-access deprecation shim.
 
-``Wkl.__getitem__`` still works for backward compatibility but emits a
-``DeprecationWarning`` pointing at the modern replacement (dot access
-or ``.search()``). DataFrame-style indexing (list/slice keys) is
-unaffected — it does not emit the warning.
+Pre-v1.3, ``Wkl.__getitem__`` accepted string keys as a deprecated
+alias for chain access / wildcard search and emitted a
+``DeprecationWarning``. In v1.3.0 the shim was removed — string
+subscripts now raise ``TypeError`` pointing at the modern replacement
+(dot access, ``.search(...)``, ``.resolve()``). See
+``docs/design/pythonic-wkl.md`` § Migration.
+
+The Surface 2 protocol (int / slice subscript) is tested in
+``tests/test_pythonic.py``.
 """
 
 from __future__ import annotations
-
-import warnings
 
 import pytest
 
@@ -16,36 +19,35 @@ import wkls
 from wkls import Wkl
 
 
-def test_bracket_access_emits_deprecation():
-    """Wkl()[...] still works but emits a DeprecationWarning."""
-    with pytest.warns(DeprecationWarning, match="Bracket access is deprecated"):
-        result = Wkl()["IN"]
-    assert result.resolve().to_arrow_table().column("country")[0].as_py() == "IN"
+def test_string_bracket_access_raises():
+    """``Wkl()["IN"]`` used to warn; v1.3 raises ``TypeError``."""
+    with pytest.raises(TypeError, match="dot access"):
+        Wkl()["IN"]
 
 
-def test_bracket_wildcard_emits_deprecation_pointing_to_search():
-    """Wildcard bracket access warns and suggests .search()."""
-    with pytest.warns(
-        DeprecationWarning, match=r"wildcards is deprecated; use \.search\('fran'\)"
-    ):
-        result = wkls.us.ca["%fran%"]
-    assert result.count() >= 1
+def test_string_bracket_access_message_points_at_search():
+    """Error message lists ``.search()`` as one of the alternatives."""
+    with pytest.raises(TypeError, match="\\.search"):
+        wkls.us["OR"]
 
 
-def test_chained_bracket_emits_deprecation():
-    """Bracket access on a chained Wkl also warns."""
-    with pytest.warns(DeprecationWarning, match="Bracket access is deprecated"):
+def test_wildcard_bracket_access_raises():
+    """``wkls.us.ca["%fran%"]`` used to warn and resolve; v1.3 raises."""
+    with pytest.raises(TypeError, match="dot access"):
+        wkls.us.ca["%fran%"]
+
+
+def test_chained_string_bracket_access_raises():
+    """Bracket chain access at any depth raises ``TypeError``."""
+    with pytest.raises(TypeError, match="dot access"):
         wkls.us["CA"]
 
 
-def test_list_style_index_does_not_warn():
-    """DataFrame-style list indexing does NOT emit the deprecation warning."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        try:
-            wkls.us.ca[["id", "country"]]
-        except DeprecationWarning:
-            pytest.fail("DataFrame-style indexing should not emit DeprecationWarning")
-        except Exception:
-            # Any other exception is fine — we're only testing the warning surface.
-            pass
+def test_list_bracket_access_raises():
+    """List keys (pre-v1.3: DataFrame column selection passthrough) now raise.
+
+    Users wanting DataFrame-style column selection should call
+    ``.resolve()`` and use the sedona DataFrame directly.
+    """
+    with pytest.raises(TypeError, match="int or slice"):
+        wkls.us.ca[["id", "country"]]

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -125,7 +125,7 @@ def test_by_id_returns_single_row():
     uid = df.column("id")[0].as_py()
     result = wkls.by_id(uid)
     assert isinstance(result, Wkl)
-    assert result.count() == 1
+    assert len(result) == 1
 
 
 def test_by_id_geometry():
@@ -214,7 +214,7 @@ def test_path_on_single_row_search_result_walks_parent_id():
     and the returned path contained only the leaf segment.
     """
     oakland = wkls.us.ca.search("oakland")
-    assert oakland.count() == 1
+    assert len(oakland) == 1
     assert oakland.path == "wkls.us.ca.alamedacounty.oakland"
 
 
@@ -254,7 +254,7 @@ def test_subtype_is_not_a_chain_filter():
     filter the current result by subtype.
     """
     multi = wkls.us.ca.search("san")
-    assert multi.count() > 1
+    assert len(multi) > 1
     # Accessing 'locality' on a result-mode Wkl should go through the
     # DataFrame passthrough (sedona DataFrames don't have a .locality
     # attribute) and raise AttributeError, NOT silently filter.

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -150,14 +150,14 @@ def test_parent_walks_up_one_level():
     sf = wkls.us.ca.sanfrancisco
     parent = sf.parent
     assert isinstance(parent, Wkl)
-    table = parent.resolve().to_arrow_table()
+    table = parent._resolve().to_arrow_table()
     assert table.column("name_primary")[0].as_py() == "California"
 
 
 def test_parent_parent_chain():
     """.parent.parent walks up two levels."""
     grandparent = wkls.us.ca.sanfrancisco.parent.parent
-    table = grandparent.resolve().to_arrow_table()
+    table = grandparent._resolve().to_arrow_table()
     assert table.column("name_primary")[0].as_py() == "United States"
 
 
@@ -225,7 +225,7 @@ def test_chain_depth_4_resolves_ambiguity():
     """wkls.us.pa.franklin is ambiguous, but parent narrower resolves it."""
     # Adams County Franklin should be unique.
     result = wkls.us.pa.adamscounty.franklin
-    assert result.resolve().count() == 1
+    assert result._resolve().count() == 1
     assert result.wkt().startswith(("POLYGON", "MULTIPOLYGON"))
 
 

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -62,7 +62,7 @@ def test_ambiguity_error_indistinguishable_candidates_uses_by_id():
         msg = str(e)
     else:
         pytest.fail("expected AmbiguousLocationError")
-    assert "No dot-access narrower" in msg
+    assert "Narrow with one of" in msg
     assert "Or pick by id" in msg
     # Two literal by_id calls, one per candidate.
     assert msg.count("wkls.by_id('") == 2

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -130,7 +130,7 @@ def test_dir_result_mode_multi_row_exposes_inspection_and_subtype_narrowers():
     subtype attribute.
     """
     entries = set(dir(wkls.us.ca.search("san francisco")))
-    assert {"count", "head", "to_arrow_table", "to_dicts"}.issubset(entries)
+    assert {"to_arrow_table", "to_dicts"}.issubset(entries)
     assert entries.isdisjoint({"wkt", "wkb", "geojson"})  # geometry would raise
     # Listing narrowers ARE advertised — they're the discovery path for
     # agents hitting AmbiguousLocationError in result-mode.
@@ -161,17 +161,13 @@ def test_dir_result_mode_single_row_exposes_geometry_and_nav():
     entries = set(dir(wkls.us.ca.search("oakland")))
     assert {"wkt", "wkb", "geojson"}.issubset(entries)
     assert {"path", "parent"}.issubset(entries)
-    assert {"count", "head", "to_arrow_table"}.issubset(entries)
+    assert {"to_arrow_table", "to_dicts"}.issubset(entries)
 
 
 def test_dir_result_mode_empty_result():
     """dir() on an empty result exposes only DataFrame inspection verbs."""
     entries = set(dir(wkls.us.ca.search("zzzzznope")))
     assert entries == {
-        "count",
-        "head",
-        "limit",
-        "show",
         "to_arrow_table",
         "to_dicts",
     }
@@ -198,8 +194,8 @@ def test_dir_cached_no_query_on_repeat(capsys):
 
 def test_search_root_returns_mixed_subtypes():
     """wkls.search() at root scans every subtype, not just countries."""
-    df = wkls.search("san francisco").to_arrow_table()
-    subtypes = {df.column("subtype")[i].as_py() for i in range(df.num_rows)}
+    rows = wkls.search("san francisco").to_dicts()
+    subtypes = {r["subtype"] for r in rows}
     assert subtypes & {"locality", "localadmin", "county"}, (
         f"Expected city-like subtypes, got {subtypes}"
     )
@@ -207,29 +203,22 @@ def test_search_root_returns_mixed_subtypes():
 
 def test_search_finds_city_from_root():
     """A root-level search for a city name returns the actual city."""
-    df = wkls.search("san francisco").to_arrow_table()
-    matches = [
-        (df.column("country")[i].as_py(), df.column("name_primary")[i].as_py())
-        for i in range(df.num_rows)
-    ]
+    rows = wkls.search("san francisco").to_dicts()
+    matches = [(r["country"], r["name_primary"]) for r in rows]
     assert ("US", "San Francisco") in matches
 
 
 def test_search_country_scope_expands():
     """search() under a country finds cities, not just regions."""
-    df = wkls.us.search("los angeles").to_arrow_table()
-    subtypes = {df.column("subtype")[i].as_py() for i in range(df.num_rows)}
+    rows = wkls.us.search("los angeles").to_dicts()
+    subtypes = {r["subtype"] for r in rows}
     assert subtypes & {"locality", "county"}
 
 
 def test_search_country_finds_regions_too():
     """Country-level search still returns region matches alongside cities."""
-    df = wkls.us.search("new").to_arrow_table()
-    names_by_subtype = {
-        (df.column("subtype")[i].as_py(), df.column("name_primary")[i].as_py())
-        for i in range(df.num_rows)
-    }
-    region_names = {n for st, n in names_by_subtype if st == "region"}
+    rows = wkls.us.search("new").to_dicts()
+    region_names = {r["name_primary"] for r in rows if r["subtype"] == "region"}
     assert {"New Hampshire", "New Jersey", "New Mexico", "New York"}.issubset(
         region_names
     )
@@ -238,9 +227,9 @@ def test_search_country_finds_regions_too():
 def test_search_region_returns_cities():
     """search() at region level returns matching cities/counties."""
     df = wkls.us.ca.search("san fran")
-    assert df.count() >= 1
-    table = df.to_arrow_table()
-    names = [table.column("name_primary")[i].as_py() for i in range(table.num_rows)]
+    assert len(df) >= 1
+    rows = df.to_dicts()
+    names = [r["name_primary"] for r in rows]
     assert any("San Francisco" in n for n in names)
 
 
@@ -264,8 +253,8 @@ def test_search_normalizes_query_to_dot_access_form():
     (lowercased + non-alphanumerics stripped). Regression: prior to
     normalization, the spaceless form returned an empty DataFrame.
     """
-    spaceless = wkls.us.ca.search("sanfrancisco").count()
-    spaced = wkls.us.ca.search("san francisco").count()
+    spaceless = len(wkls.us.ca.search("sanfrancisco"))
+    spaced = len(wkls.us.ca.search("san francisco"))
     assert spaceless == spaced
     assert spaceless >= 1  # at least the SF locality
 
@@ -280,15 +269,15 @@ def test_search_chains_narrow_within_prior_result():
     the US/CA scope.
     """
     narrowed = wkls.us.ca.search("san").search("san francisco")
-    tbl = narrowed.to_arrow_table()
-    countries = {tbl.column("country")[i].as_py() for i in range(tbl.num_rows)}
-    regions = {tbl.column("region")[i].as_py() for i in range(tbl.num_rows)}
+    rows = narrowed.to_dicts()
+    countries = {r["country"] for r in rows}
+    regions = {r["region"] for r in rows}
     # Must be a subset of the prior scope (US/CA).
     assert countries == {"US"}
     assert regions == {"US-CA"}
     # Must match the single-call equivalent (same final scope, same query).
-    single = wkls.us.ca.search("san francisco").count()
-    assert narrowed.count() == single
+    single = len(wkls.us.ca.search("san francisco"))
+    assert len(narrowed) == single
 
 
 def test_search_chains_on_root_result_still_narrows():
@@ -297,14 +286,10 @@ def test_search_chains_on_root_result_still_narrows():
     second = first.search("san")
     # Every row in `second` must also be in `first` — narrowing, not
     # re-scanning.
-    first_ids = {
-        first.to_arrow_table().column("id")[i].as_py() for i in range(first.count())
-    }
-    second_ids = {
-        second.to_arrow_table().column("id")[i].as_py() for i in range(second.count())
-    }
+    first_ids = {r["id"] for r in first.to_dicts()}
+    second_ids = {r["id"] for r in second.to_dicts()}
     assert second_ids.issubset(first_ids)
-    assert second.count() < first.count()
+    assert len(second) < len(first)
 
 
 # ---------- Listing methods narrow on result-mode ----------
@@ -317,55 +302,47 @@ def test_counties_narrows_on_result_mode():
     of thousands of counties unrelated to the prior search.
     """
     prior = wkls.us.search("san")
-    assert prior.count() > 1
+    assert len(prior) > 1
     narrowed = prior.counties()
-    prior_ids = {
-        prior.to_arrow_table().column("id")[i].as_py() for i in range(prior.count())
-    }
-    tbl = narrowed.to_arrow_table()
-    for i in range(tbl.num_rows):
-        assert tbl.column("subtype")[i].as_py() == "county"
-        assert tbl.column("id")[i].as_py() in prior_ids
+    prior_ids = {r["id"] for r in prior.to_dicts()}
+    narrowed_rows = narrowed.to_dicts()
+    for r in narrowed_rows:
+        assert r["subtype"] == "county"
+        assert r["id"] in prior_ids
 
 
 def test_cities_narrows_on_result_mode():
     """cities() on a result-mode Wkl filters to locality/localadmin rows."""
     prior = wkls.us.search("san")
     narrowed = prior.cities()
-    subtypes = {
-        narrowed.to_arrow_table().column("subtype")[i].as_py()
-        for i in range(narrowed.count())
-    }
+    subtypes = {r["subtype"] for r in narrowed.to_dicts()}
     assert subtypes.issubset({"locality", "localadmin"})
 
 
 def test_countries_narrows_on_result_mode():
     """countries() on a result-mode Wkl filters to country rows in the prior result."""
     # A name that doesn't match any country — should narrow to empty.
-    assert wkls.search("franklin").countries().count() == 0
+    assert len(wkls.search("franklin").countries()) == 0
     # A name that does — should include at least that country.
     united = wkls.search("united").countries()
-    tbl = united.to_arrow_table()
-    subtypes = {tbl.column("subtype")[i].as_py() for i in range(tbl.num_rows)}
+    rows = united.to_dicts()
+    subtypes = {r["subtype"] for r in rows}
     assert subtypes == {"country"}
-    assert united.count() >= 1
+    assert len(united) >= 1
 
 
 def test_dependencies_narrows_on_result_mode():
     """dependencies() on a result-mode Wkl filters to dependency rows."""
     result = wkls.search("united").dependencies()
-    tbl = result.to_arrow_table()
-    for i in range(tbl.num_rows):
-        assert tbl.column("subtype")[i].as_py() == "dependency"
+    rows = result.to_dicts()
+    for r in rows:
+        assert r["subtype"] == "dependency"
 
 
 def test_subtypes_narrows_on_result_mode():
     """subtypes() on a result-mode Wkl lists distinct subtypes in the prior rows."""
     result = wkls.us.search("san").subtypes()
-    vals = {
-        result.to_arrow_table().column("subtype")[i].as_py()
-        for i in range(result.count())
-    }
+    vals = {r["subtype"] for r in result.to_dicts()}
     # Must be a subset of real subtypes (no spurious global ones).
     assert vals <= {
         "country",
@@ -417,53 +394,53 @@ def test_to_dicts_in_result_mode_dir():
 
 def test_regions_at_root_returns_all():
     """wkls.regions() at root returns every region worldwide."""
-    assert wkls.regions().count() > 3000  # ~3,900 in practice
+    assert len(wkls.regions()) > 3000  # ~3,900 in practice
 
 
 def test_regions_scoped_to_country():
     """wkls.us.regions() returns regions scoped to that country."""
-    assert wkls.us.regions().count() == 51  # 50 states + DC
+    assert len(wkls.us.regions()) == 51  # 50 states + DC
 
 
 def test_india_regions_count():
     """Canonical dataset sanity check."""
-    assert wkls.IN.regions().count() == 37
+    assert len(wkls.IN.regions()) == 37
 
 
 def test_counties_at_country_level():
     """wkls.us.counties() returns counties in the US."""
-    assert wkls.us.counties().count() > 3000
+    assert len(wkls.us.counties()) > 3000
 
 
 def test_cities_at_country_level():
     """wkls.us.cities() returns cities in the US."""
-    assert wkls.us.cities().count() > 10000
+    assert len(wkls.us.cities()) > 10000
 
 
 def test_counties_at_region_level():
     """wkls.us.ca.counties() returns CA counties."""
-    assert wkls.us.ca.counties().count() == 58  # California has 58 counties
+    assert len(wkls.us.ca.counties()) == 58  # California has 58 counties
 
 
 def test_counties_at_root_returns_all():
     """wkls.counties() at root lists every county worldwide."""
-    assert wkls.counties().count() > 10000
+    assert len(wkls.counties()) > 10000
 
 
 def test_cities_at_root_returns_all():
     """wkls.cities() at root lists every city worldwide."""
-    assert wkls.cities().count() > 100000
+    assert len(wkls.cities()) > 100000
 
 
 def test_no_region_country_counties_and_cities():
     """Depth-1 list methods on no-region countries (FK) still work."""
-    assert wkls.fk.counties().count() >= 0
-    assert wkls.fk.cities().count() >= 1
+    assert len(wkls.fk.counties()) >= 0
+    assert len(wkls.fk.cities()) >= 1
 
 
 def test_fk_cities_count():
     """Canonical dataset sanity check."""
-    assert wkls.fk.cities().count() == 25
+    assert len(wkls.fk.cities()) == 25
 
 
 # ---------- List-method depth guards ----------
@@ -471,14 +448,14 @@ def test_fk_cities_count():
 
 def test_regions_at_region_level_returns_self():
     """regions() at region level returns the region itself — only region in scope."""
-    df = wkls.us.ca.regions().to_arrow_table()
-    assert df.num_rows == 1
-    assert df.column("region")[0].as_py() == "US-CA"
+    rows = wkls.us.ca.regions().to_dicts()
+    assert len(rows) == 1
+    assert rows[0]["region"] == "US-CA"
 
 
 def test_regions_past_region_level_returns_empty():
     """regions() past region level cascades via parent_id; a locality has no sub-regions."""
-    assert wkls.us.ca.sanfrancisco.regions().count() == 0
+    assert len(wkls.us.ca.sanfrancisco.regions()) == 0
 
 
 def test_counties_past_region_level_self_inclusive():
@@ -488,16 +465,16 @@ def test_counties_past_region_level_self_inclusive():
     city-county), so .counties() on it returns [SF].
     """
     result = wkls.us.ca.sanfrancisco.counties()
-    assert result.count() == 1
-    assert result.to_arrow_table().column("name_primary")[0].as_py() == "San Francisco"
+    assert len(result) == 1
+    assert result.to_dicts()[0]["name_primary"] == "San Francisco"
 
 
 def test_cities_at_county_level_returns_children():
     """cities() on a county returns its direct locality/localadmin children via parent_id."""
     cities = wkls.us.ca.sandiegocounty.cities()
-    assert cities.count() >= 15  # San Diego County has ~19 localities
-    table = cities.to_arrow_table()
-    names = {table.column("name_primary")[i].as_py() for i in range(table.num_rows)}
+    assert len(cities) >= 15  # San Diego County has ~19 localities
+    rows = cities.to_dicts()
+    names = {r["name_primary"] for r in rows}
     assert {"San Diego", "Chula Vista", "Oceanside"}.issubset(names)
 
 
@@ -512,18 +489,18 @@ def test_cities_past_region_level_on_ambiguous_raises():
 
 def test_countries_at_root():
     """Canonical country count."""
-    assert wkls.countries().count() == 219
+    assert len(wkls.countries()) == 219
 
 
 def test_dependencies_at_root():
     """Canonical dependency count."""
-    assert wkls.dependencies().count() == 53
+    assert len(wkls.dependencies()) == 53
 
 
 def test_subtypes_at_root():
     """subtypes() at root returns the distinct set of subtypes in the dataset."""
-    table = wkls.subtypes().to_arrow_table()
-    subtype_values = {table.column("subtype")[i].as_py() for i in range(table.num_rows)}
+    rows = wkls.subtypes().to_dicts()
+    subtype_values = {r["subtype"] for r in rows}
     for expected in ("country", "region", "county", "locality", "localadmin"):
         assert expected in subtype_values, f"Missing subtype: {expected}"
 
@@ -531,44 +508,44 @@ def test_subtypes_at_root():
 def test_countries_scope_narrows_to_self_on_country_chain():
     """wkls.us.countries() returns [US] — the country that contains the chain."""
     result = wkls.us.countries()
-    assert result.count() == 1
-    tbl = result.to_arrow_table()
-    assert tbl.column("country")[0].as_py() == "US"
-    assert tbl.column("subtype")[0].as_py() == "country"
+    assert len(result) == 1
+    rows = result.to_dicts()
+    assert rows[0]["country"] == "US"
+    assert rows[0]["subtype"] == "country"
 
 
 def test_countries_scope_narrows_to_self_past_country_chain():
     """countries() at region or city depth still returns the containing country."""
-    assert wkls.us.ca.countries().count() == 1
-    assert wkls.us.ca.sanfrancisco.countries().count() == 1
+    assert len(wkls.us.ca.countries()) == 1
+    assert len(wkls.us.ca.sanfrancisco.countries()) == 1
 
 
 def test_dependencies_scope_empty_on_country_chain():
     """wkls.us.dependencies() returns [] — US is a country, no dependencies in scope."""
-    assert wkls.us.dependencies().count() == 0
+    assert len(wkls.us.dependencies()) == 0
 
 
 def test_dependencies_scope_narrows_to_self_on_dependency_chain():
     """wkls.pr.dependencies() returns [PR] — PR's subtype is 'dependency'."""
     result = wkls.pr.dependencies()
-    assert result.count() == 1
-    tbl = result.to_arrow_table()
-    assert tbl.column("country")[0].as_py() == "PR"
-    assert tbl.column("subtype")[0].as_py() == "dependency"
+    assert len(result) == 1
+    rows = result.to_dicts()
+    assert rows[0]["country"] == "PR"
+    assert rows[0]["subtype"] == "dependency"
 
 
 def test_subtypes_scope_narrows_to_country():
     """wkls.us.subtypes() lists distinct subtypes present in the US."""
-    tbl = wkls.us.subtypes().to_arrow_table()
-    values = {tbl.column("subtype")[i].as_py() for i in range(tbl.num_rows)}
+    rows = wkls.us.subtypes().to_dicts()
+    values = {r["subtype"] for r in rows}
     # US has country + region + county + locality at minimum.
     assert {"country", "region", "county", "locality"}.issubset(values)
 
 
 def test_subtypes_scope_narrows_to_region():
     """wkls.us.ca.subtypes() lists distinct subtypes present in CA."""
-    tbl = wkls.us.ca.subtypes().to_arrow_table()
-    values = {tbl.column("subtype")[i].as_py() for i in range(tbl.num_rows)}
+    rows = wkls.us.ca.subtypes().to_dicts()
+    values = {r["subtype"] for r in rows}
     # CA is itself a region; its subtree adds county + locality + localadmin.
     assert "region" in values
     assert values & {"county", "locality", "localadmin"}
@@ -579,8 +556,8 @@ def test_subtypes_no_region_scope():
 
     FK is itself a dependency, so its subtype scope is {dependency, locality}.
     """
-    tbl = wkls.fk.subtypes().to_arrow_table()
-    values = {tbl.column("subtype")[i].as_py() for i in range(tbl.num_rows)}
+    rows = wkls.fk.subtypes().to_dicts()
+    values = {r["subtype"] for r in rows}
     assert "region" not in values
     assert "dependency" in values  # FK is a dependency
     assert "locality" in values  # FK has localities
@@ -602,11 +579,8 @@ def test_cities_at_locality_level_includes_self():
     """
     oakland = wkls.us.ca.alamedacounty.oakland
     cities = oakland.cities()
-    assert cities.count() >= 1
-    names = {
-        cities.to_arrow_table().column("name_primary")[i].as_py()
-        for i in range(cities.count())
-    }
+    assert len(cities) >= 1
+    names = {r["name_primary"] for r in cities.to_dicts()}
     assert "Oakland" in names
 
 
@@ -615,7 +589,7 @@ def test_counties_at_county_level_includes_self():
     sf = wkls.us.ca.sanfrancisco
     # Overture models SF as a county (consolidated city-county).
     counties = sf.counties()
-    assert counties.count() == 1
-    tbl = counties.to_arrow_table()
-    assert tbl.column("name_primary")[0].as_py() == "San Francisco"
-    assert tbl.column("subtype")[0].as_py() == "county"
+    assert len(counties) == 1
+    rows = counties.to_dicts()
+    assert rows[0]["name_primary"] == "San Francisco"
+    assert rows[0]["subtype"] == "county"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -142,16 +142,10 @@ def test_suggestions_show_in_empty_repr():
     assert "wkls.us.ca.search('sanfran')" in repr_str
 
 
-def test_suggestions_via_Wkl_bracket_access(ignore_bracket_deprecation):
-    """Bracket access on a Wkl instance surfaces the same hint."""
-    from wkls import Wkl
-
-    result = Wkl()["uss"]
-    repr_str = repr(result)
-    assert "No results found for: uss" in repr_str
-    assert "Did you mean:" in repr_str
-    assert "us" in repr_str
-    assert "wkls.search('uss')" in repr_str
+# NOTE: The pre-v1.3 companion test for bracket access on a Wkl instance
+# (`Wkl()["uss"]` returning a Wkl with a "Did you mean:" hint in repr) was
+# removed when the bracket-access shim was replaced with a TypeError in
+# v1.3.0. TypeError coverage lives in tests/test_deprecation.py.
 
 
 # ---------- Error propagation on chained Wkl ----------

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -142,10 +142,10 @@ def test_suggestions_show_in_empty_repr():
     assert "wkls.us.ca.search('sanfran')" in repr_str
 
 
-# NOTE: The pre-v1.3 companion test for bracket access on a Wkl instance
+# NOTE: The pre-v1.2 companion test for bracket access on a Wkl instance
 # (`Wkl()["uss"]` returning a Wkl with a "Did you mean:" hint in repr) was
 # removed when the bracket-access shim was replaced with a TypeError in
-# v1.3.0. TypeError coverage lives in tests/test_deprecation.py.
+# v1.2.0. TypeError coverage lives in tests/test_deprecation.py.
 
 
 # ---------- Error propagation on chained Wkl ----------

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,7 +1,7 @@
 """Tests for geometry output formats and Arrow interop.
 
-Covers ``.wkt()``, ``.wkb()``, ``.geojson()``, the unimplemented
-``.hexwkb()`` and ``.svg()`` stubs, Arrow C data protocol, and the
+Covers ``.wkt()``, ``.wkb()``, ``.geojson()``, removal of
+``.hexwkb()`` and ``.svg()``, Arrow C data protocol, and the
 failure path when geometry methods are called on empty resolve results.
 """
 
@@ -43,14 +43,14 @@ def test_geojson(sf):
     assert parsed["type"] == "MultiPolygon"
 
 
-def test_hexwkb_not_implemented(sf):
-    with pytest.raises(NotImplementedError):
-        sf.hexwkb()
+def test_hexwkb_removed():
+    """hexwkb() no longer exists on Wkl — removed in v1.2.0."""
+    assert not hasattr(wkls.Wkl, "hexwkb")
 
 
-def test_svg_not_implemented(sf):
-    with pytest.raises(NotImplementedError):
-        sf.svg()
+def test_svg_removed():
+    """svg() no longer exists on Wkl — removed in v1.2.0."""
+    assert not hasattr(wkls.Wkl, "svg")
 
 
 def test_arrow_interop(sf):

--- a/tests/test_lazy_overture.py
+++ b/tests/test_lazy_overture.py
@@ -36,10 +36,10 @@ urllib.request.urlopen = lambda *a, **kw: (_ for _ in ()).throw(
 
 import wkls  # must not raise
 
-assert wkls.countries().count() > 0, "countries() should work offline"
-assert wkls.us.regions().count() > 0, "regions() should work offline"
+assert len(wkls.countries()) > 0, "countries() should work offline"
+assert len(wkls.us.regions()) > 0, "regions() should work offline"
 assert wkls.us.ca.sanfrancisco._resolve().count() == 1, "chain resolution should work offline"
-assert wkls.us.ca.search('oakland').count() >= 1, "search should work offline"
+assert len(wkls.us.ca.search('oakland')) >= 1, "search should work offline"
 print("OK")
 """
     result = subprocess.run(

--- a/tests/test_lazy_overture.py
+++ b/tests/test_lazy_overture.py
@@ -38,7 +38,7 @@ import wkls  # must not raise
 
 assert wkls.countries().count() > 0, "countries() should work offline"
 assert wkls.us.regions().count() > 0, "regions() should work offline"
-assert wkls.us.ca.sanfrancisco.resolve().count() == 1, "chain resolution should work offline"
+assert wkls.us.ca.sanfrancisco._resolve().count() == 1, "chain resolution should work offline"
 assert wkls.us.ca.search('oakland').count() >= 1, "search should work offline"
 print("OK")
 """

--- a/tests/test_pythonic.py
+++ b/tests/test_pythonic.py
@@ -364,3 +364,16 @@ def test_row_parent_walks_up():
     assert len(parent_rows) == 1
     assert parent_rows[0]["country"] == "US"
     assert parent_rows[0]["region"] == "US-CA"
+
+
+# ── svg / hexwkb removal (v1.2.0) ──────────────────────────────────
+
+
+def test_svg_removed():
+    """svg() no longer exists on Wkl."""
+    assert not hasattr(wkls.Wkl, "svg")
+
+
+def test_hexwkb_removed():
+    """hexwkb() no longer exists on Wkl."""
+    assert not hasattr(wkls.Wkl, "hexwkb")

--- a/tests/test_pythonic.py
+++ b/tests/test_pythonic.py
@@ -34,10 +34,11 @@ def test_len_on_chain_mode():
     assert len(wkls.us.ca.counties()) >= 1
 
 
-def test_len_matches_count():
-    """len(wkl) and wkl.count() must agree."""
+def test_len_returns_int():
+    """len(wkl) returns a positive integer for a valid result."""
     counties = wkls.us.ca.counties()
-    assert len(counties) == counties.count()
+    assert isinstance(len(counties), int)
+    assert len(counties) > 0
 
 
 def test_len_on_empty_result():
@@ -226,70 +227,92 @@ def test_slice_then_list():
     assert all(isinstance(x, Wkl) for x in lst)
 
 
-# ---------- head / limit return Wkl (was: sedona DataFrame) ----------
+# ---------- slice returns Wkl (was: .head/.limit passthrough) ----------
 
 
-def test_head_returns_wkl():
-    """Behavior change from v1.2: .head(n) wraps its return in a Wkl."""
-    result = wkls.us.ca.counties().head(3)
+def test_slice_returns_wkl():
+    """wkl[:n] returns a Wkl with n rows."""
+    result = wkls.us.ca.counties()[:3]
     assert isinstance(result, Wkl)
     assert len(result) == 3
 
 
-def test_limit_returns_wkl():
-    result = wkls.us.ca.counties().limit(3)
-    assert isinstance(result, Wkl)
-    assert len(result) == 3
-
-
-def test_head_to_dicts_chain():
-    """Copilot-review bug: .head(3).to_dicts() end-to-end.
-
-    Before v1.3 this failed because .head returned a sedona DataFrame
-    which has no .to_dicts method.
-    """
-    rows = wkls.us.ca.counties().head(3).to_dicts()
+def test_slice_to_dicts_chain():
+    """wkl[:3].to_dicts() end-to-end."""
+    rows = wkls.us.ca.counties()[:3].to_dicts()
     assert isinstance(rows, list)
     assert len(rows) == 3
     assert all(isinstance(r, dict) for r in rows)
 
 
-# ---------- narrowed __getattr__ passthrough ----------
+# ---------- __getattr__ redirects ----------
 
 
-def test_filter_raises_attribute_error():
-    """`.filter()` used to silently pass through to sedona; now it raises."""
-    with pytest.raises(AttributeError, match=r"\.to_arrow_table\(\)"):
-        wkls.us.ca.counties().filter(None)
+def test_filter_redirects_to_search_and_arrow():
+    """filter() suggests .search() first, then .to_arrow_table()."""
+    with pytest.raises(AttributeError, match="search"):
+        wkls.us.ca.cities().filter  # noqa: B018
 
 
-def test_select_raises_attribute_error():
-    with pytest.raises(AttributeError, match=r"\.to_arrow_table\(\)"):
-        wkls.us.ca.counties().select("id")
+def test_select_redirects_to_arrow_table():
+    with pytest.raises(AttributeError, match="to_arrow_table"):
+        wkls.us.ca.cities().select  # noqa: B018
 
 
-def test_group_by_raises_attribute_error():
-    with pytest.raises(AttributeError, match=r"\.to_arrow_table\(\)"):
-        wkls.us.ca.counties().group_by("subtype")
+def test_group_by_redirects_to_arrow_table():
+    with pytest.raises(AttributeError, match="to_arrow_table"):
+        wkls.us.ca.cities().group_by  # noqa: B018
 
 
-def test_arbitrary_sedona_method_raises():
-    with pytest.raises(AttributeError, match=r"\.to_arrow_table\(\)"):
-        wkls.us.ca.counties().nonexistent_method()
+def test_count_redirects_to_len():
+    """count() suggests len(wkl)."""
+    with pytest.raises(AttributeError, match="len"):
+        wkls.us.ca.cities().count  # noqa: B018
 
 
-# ---------- allowlisted passthroughs unchanged ----------
+def test_head_redirects_to_slice():
+    """head() suggests wkl[:n]."""
+    with pytest.raises(AttributeError, match=r"\[:n\]"):
+        wkls.us.ca.cities().head  # noqa: B018
 
 
-def test_count_unchanged():
-    assert isinstance(wkls.us.ca.counties().count(), int)
+def test_show_redirects_to_slice():
+    """show() suggests wkl[:n]."""
+    with pytest.raises(AttributeError, match=r"\[:n\]"):
+        wkls.us.ca.cities().show  # noqa: B018
 
 
-def test_show_unchanged(capsys):
-    result = wkls.us.ca.counties().head(1).show()
-    # show() returns None and prints to stdout. We don't assert on the
-    # exact output to avoid coupling to sedona's formatting.
-    assert result is None
+def test_resolve_redirects_to_arrow_table():
+    """resolve() suggests .to_arrow_table() (renamed)."""
+    with pytest.raises(AttributeError, match="to_arrow_table"):
+        wkls.us.ca.cities().resolve  # noqa: B018
+
+
+def test_collect_redirects_to_list():
+    """collect() suggests list(wkl)."""
+    with pytest.raises(AttributeError, match="list"):
+        wkls.us.ca.cities().collect  # noqa: B018
+
+
+def test_to_pandas_redirects_to_arrow_table():
+    """to_pandas() suggests .to_arrow_table().to_pandas()."""
+    with pytest.raises(AttributeError, match="to_arrow_table"):
+        wkls.us.ca.cities().to_pandas  # noqa: B018
+
+
+def test_unknown_attr_generic_fallback():
+    """Unknown non-location attr gets generic .to_arrow_table() redirect."""
+    with pytest.raises(AttributeError, match="to_arrow_table"):
+        wkls.us.ca.cities().foobar_nonexistent  # noqa: B018
+
+
+def test_chain_drill_still_works():
+    """Valid location names still chain-drill normally."""
+    result = wkls.us.ca  # should not raise
+    assert result is not None
+
+
+# ---------- real methods still work ----------
 
 
 def test_to_arrow_table_unchanged():

--- a/tests/test_pythonic.py
+++ b/tests/test_pythonic.py
@@ -400,3 +400,9 @@ def test_svg_removed():
 def test_hexwkb_removed():
     """hexwkb() no longer exists on Wkl."""
     assert not hasattr(wkls.Wkl, "hexwkb")
+
+
+def test_redirect_fires_on_chain_mode():
+    """Known DataFrame verbs redirect even on chain-mode Wkls."""
+    with pytest.raises(AttributeError, match="search"):
+        wkls.us.ca.filter  # noqa: B018

--- a/tests/test_pythonic.py
+++ b/tests/test_pythonic.py
@@ -1,0 +1,366 @@
+"""Tests for the Surface 2 Python collection protocol on ``Wkl``.
+
+Covers the v1.3.0 changes:
+
+- Collection dunders (``__len__``, ``__bool__``, ``__iter__``,
+  ``__getitem__``, ``__contains__``).
+- Iteration yields single-row ``Wkl`` instances that support ``.wkt()``,
+  ``.path``, ``.parent``, etc.
+- ``.head(n)`` / ``.limit(n)`` now return ``Wkl`` (was: sedona DataFrame).
+- ``__getattr__`` passthrough narrowed to the allowlist in
+  ``_DIR_DATAFRAME_METHODS``. ``.filter`` / ``.select`` / etc. raise
+  ``AttributeError`` pointing at ``.resolve()``.
+- Bracket string subscript raises ``TypeError`` (was: ``DeprecationWarning``
+  shim for chain access / wildcard).
+
+See the v1.3.0 release notes for the full contract this test suite
+validates.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+import sedonadb
+
+import wkls
+from wkls import Wkl
+
+# ---------- __len__ / __bool__ ----------
+
+
+def test_len_on_chain_mode():
+    """len() on a chain-mode listing returns the expected count."""
+    assert len(wkls.us.ca.counties()) >= 1
+
+
+def test_len_matches_count():
+    """len(wkl) and wkl.count() must agree."""
+    counties = wkls.us.ca.counties()
+    assert len(counties) == counties.count()
+
+
+def test_len_on_empty_result():
+    """len() on a zero-row search result is 0."""
+    assert len(wkls.us.ca.search("zzznope-no-such-place")) == 0
+
+
+def test_len_on_root_raises():
+    """len(Wkl()) raises TypeError pointing at dot access."""
+    with pytest.raises(TypeError, match="Root Wkl has no rows"):
+        len(Wkl())
+
+
+def test_bool_nonempty():
+    assert bool(wkls.us.ca.counties()) is True
+
+
+def test_bool_empty():
+    assert bool(wkls.us.ca.search("zzznope-no-such-place")) is False
+
+
+def test_bool_on_root_raises():
+    with pytest.raises(TypeError, match="Root Wkl has no rows"):
+        bool(Wkl())
+
+
+# ---------- __iter__ ----------
+
+
+def test_iter_yields_wkls():
+    """Every item yielded by iteration is a ``Wkl`` instance."""
+    assert all(isinstance(x, Wkl) for x in wkls.us.ca.counties())
+
+
+def test_iter_count_matches_len():
+    """Iterator exhausts the full set of rows."""
+    counties = wkls.us.ca.counties()
+    assert len(list(counties)) == len(counties)
+
+
+def test_iter_rows_are_single_row():
+    """Each yielded row is a single-row Wkl usable for geometry."""
+    counties = wkls.us.ca.counties()
+    first = next(iter(counties))
+    assert len(first) == 1
+    wkt = first.wkt()
+    assert isinstance(wkt, str)
+    assert len(wkt) > 0
+
+
+def test_iter_on_root_raises():
+    with pytest.raises(TypeError, match="Root Wkl has no rows"):
+        iter(Wkl())
+
+
+def test_iter_on_empty_result_yields_nothing():
+    assert list(wkls.us.ca.search("zzznope-no-such-place")) == []
+
+
+# ---------- __getitem__(int) ----------
+
+
+def test_getitem_int_returns_single_row_wkl():
+    row = wkls.us.ca.counties()[0]
+    assert isinstance(row, Wkl)
+    assert len(row) == 1
+
+
+def test_getitem_negative_index():
+    counties = wkls.us.ca.counties()
+    assert (
+        wkls.us.ca.counties()[-1].to_dicts() == counties[len(counties) - 1].to_dicts()
+    )
+
+
+def test_getitem_int_out_of_range():
+    with pytest.raises(IndexError, match="out of range"):
+        wkls.us.ca.counties()[999]
+
+
+def test_getitem_int_negative_out_of_range():
+    with pytest.raises(IndexError, match="out of range"):
+        wkls.us.ca.counties()[-999]
+
+
+def test_getitem_on_root_raises():
+    with pytest.raises(TypeError, match="Root Wkl has no rows"):
+        Wkl()[0]
+
+
+# ---------- __getitem__(slice) ----------
+
+
+def test_getitem_slice_returns_wkl():
+    result = wkls.us.ca.counties()[:5]
+    assert isinstance(result, Wkl)
+    assert len(result) == 5
+
+
+def test_getitem_empty_slice():
+    assert len(wkls.us.ca.counties()[1000:2000]) == 0
+
+
+def test_getitem_negative_slice():
+    counties = wkls.us.ca.counties()
+    assert len(counties[-3:]) == 3
+
+
+def test_getitem_stepped_slice_raises():
+    with pytest.raises(TypeError, match="step"):
+        wkls.us.ca.counties()[::2]
+
+
+# ---------- __getitem__(str / other) ----------
+
+
+def test_getitem_str_raises():
+    """String subscripts raise TypeError with Surface-1 guidance.
+
+    Breaking change from v1.2: the old DeprecationWarning shim for
+    ``wkls.us["OR"]`` / ``wkls.us.ca["%San%"]`` is removed. Dot access
+    and ``.search(...)`` are the documented paths.
+    """
+    with pytest.raises(TypeError, match="dot access"):
+        wkls.us["OR"]
+
+
+def test_getitem_wildcard_str_raises():
+    with pytest.raises(TypeError, match="search"):
+        wkls.us.ca["%San%"]
+
+
+def test_getitem_list_raises():
+    with pytest.raises(TypeError, match="int or slice"):
+        wkls.us.ca.counties()[[1, 2]]
+
+
+def test_getitem_bool_raises():
+    """bool is a subclass of int in Python; explicitly reject to avoid surprises."""
+    with pytest.raises(TypeError, match="int or slice"):
+        wkls.us.ca.counties()[True]
+
+
+# ---------- __contains__ ----------
+
+
+def test_contains_uuid_hit():
+    counties = wkls.us.ca.counties()
+    uid = counties.to_dicts()[0]["id"]
+    assert uid in counties
+
+
+def test_contains_uuid_miss():
+    assert "00000000-0000-0000-0000-000000000000" not in wkls.us.ca.counties()
+
+
+def test_contains_non_string_is_false():
+    """Non-string items return False, not TypeError (soft-check idiom)."""
+    assert (123 in wkls.us.ca.counties()) is False
+
+
+def test_contains_on_root_is_false():
+    """Soft-check: no rows to inspect → False, not TypeError."""
+    assert ("anything" in Wkl()) is False
+
+
+# ---------- list / tuple conversions ----------
+
+
+def test_list_conversion():
+    counties = wkls.us.ca.counties()
+    lst = list(counties)
+    assert len(lst) == len(counties)
+    assert all(isinstance(x, Wkl) for x in lst)
+
+
+def test_tuple_conversion():
+    counties = wkls.us.ca.counties()
+    tup = tuple(counties)
+    assert len(tup) == len(counties)
+
+
+def test_slice_then_list():
+    lst = list(wkls.us.ca.counties()[:3])
+    assert len(lst) == 3
+    assert all(isinstance(x, Wkl) for x in lst)
+
+
+# ---------- head / limit return Wkl (was: sedona DataFrame) ----------
+
+
+def test_head_returns_wkl():
+    """Behavior change from v1.2: .head(n) wraps its return in a Wkl."""
+    result = wkls.us.ca.counties().head(3)
+    assert isinstance(result, Wkl)
+    assert len(result) == 3
+
+
+def test_limit_returns_wkl():
+    result = wkls.us.ca.counties().limit(3)
+    assert isinstance(result, Wkl)
+    assert len(result) == 3
+
+
+def test_head_to_dicts_chain():
+    """Copilot-review bug: .head(3).to_dicts() end-to-end.
+
+    Before v1.3 this failed because .head returned a sedona DataFrame
+    which has no .to_dicts method.
+    """
+    rows = wkls.us.ca.counties().head(3).to_dicts()
+    assert isinstance(rows, list)
+    assert len(rows) == 3
+    assert all(isinstance(r, dict) for r in rows)
+
+
+# ---------- narrowed __getattr__ passthrough ----------
+
+
+def test_filter_raises_attribute_error():
+    """`.filter()` used to silently pass through to sedona; now it raises."""
+    with pytest.raises(AttributeError, match=r"\.resolve\(\)"):
+        wkls.us.ca.counties().filter(None)
+
+
+def test_select_raises_attribute_error():
+    with pytest.raises(AttributeError, match=r"\.resolve\(\)"):
+        wkls.us.ca.counties().select("id")
+
+
+def test_group_by_raises_attribute_error():
+    with pytest.raises(AttributeError, match=r"\.resolve\(\)"):
+        wkls.us.ca.counties().group_by("subtype")
+
+
+def test_arbitrary_sedona_method_raises():
+    with pytest.raises(AttributeError, match=r"\.resolve\(\)"):
+        wkls.us.ca.counties().nonexistent_method()
+
+
+# ---------- allowlisted passthroughs unchanged ----------
+
+
+def test_count_unchanged():
+    assert isinstance(wkls.us.ca.counties().count(), int)
+
+
+def test_show_unchanged(capsys):
+    result = wkls.us.ca.counties().head(1).show()
+    # show() returns None and prints to stdout. We don't assert on the
+    # exact output to avoid coupling to sedona's formatting.
+    assert result is None
+
+
+def test_to_arrow_table_unchanged():
+    tbl = wkls.us.ca.counties().to_arrow_table()
+    assert isinstance(tbl, pa.Table)
+
+
+def test_to_dicts_unchanged():
+    rows = wkls.us.ca.counties().to_dicts()
+    assert isinstance(rows, list)
+    assert all(isinstance(r, dict) for r in rows)
+
+
+# ---------- Surface 3: .resolve() escape ----------
+
+
+def test_resolve_returns_sedona_dataframe():
+    df = wkls.us.ca.counties().resolve()
+    assert isinstance(df, sedonadb.dataframe.DataFrame)
+
+
+def test_resolve_supports_sedona_api():
+    """The object returned by .resolve() is a real sedona DataFrame.
+
+    Surface 3's contract: .resolve() hands you sedona's API. We don't
+    re-test sedona's behavior here; we just confirm the handoff works
+    and users can call sedona-native methods on the result.
+    """
+    df = wkls.us.ca.counties().resolve()
+    assert isinstance(df, sedonadb.dataframe.DataFrame)
+    # Call something sedona-native (not surfaced on Wkl directly).
+    assert df.count() >= 1
+    df.show()  # sedona's show, not wkl's — should just print and return None
+
+
+# ---------- chain-mode iteration (not-yet-resolved Wkl) ----------
+
+
+def test_chain_mode_iter_resolves_transparently():
+    """Iterating a chain-mode Wkl that hasn't been resolved yet works."""
+    rows = list(wkls.us.ca.search("san"))
+    assert len(rows) >= 2
+    assert all(isinstance(r, Wkl) for r in rows)
+
+
+# ---------- row-Wkl integration ----------
+
+
+def test_row_wkt_end_to_end():
+    row = wkls.us.ca.counties()[0]
+    wkt = row.wkt()
+    assert wkt.startswith(("POLYGON", "MULTIPOLYGON"))
+
+
+def test_row_path_end_to_end():
+    row = wkls.us.ca.counties()[0]
+    assert row.path.startswith("wkls.us.ca.")
+
+
+def test_row_to_dicts_single_element():
+    row = wkls.us.ca.counties()[0]
+    rows = row.to_dicts()
+    assert len(rows) == 1
+    assert isinstance(rows[0], dict)
+
+
+def test_row_parent_walks_up():
+    row = wkls.us.ca.counties()[0]
+    parent = row.parent
+    # Parent of a California county is California.
+    parent_rows = parent.to_dicts()
+    assert len(parent_rows) == 1
+    assert parent_rows[0]["country"] == "US"
+    assert parent_rows[0]["region"] == "US-CA"

--- a/tests/test_pythonic.py
+++ b/tests/test_pythonic.py
@@ -9,7 +9,7 @@ Covers the v1.3.0 changes:
 - ``.head(n)`` / ``.limit(n)`` now return ``Wkl`` (was: sedona DataFrame).
 - ``__getattr__`` passthrough narrowed to the allowlist in
   ``_DIR_DATAFRAME_METHODS``. ``.filter`` / ``.select`` / etc. raise
-  ``AttributeError`` pointing at ``.resolve()``.
+   ``AttributeError`` pointing at ``.to_arrow_table()``.
 - Bracket string subscript raises ``TypeError`` (was: ``DeprecationWarning``
   shim for chain access / wildcard).
 
@@ -259,22 +259,22 @@ def test_head_to_dicts_chain():
 
 def test_filter_raises_attribute_error():
     """`.filter()` used to silently pass through to sedona; now it raises."""
-    with pytest.raises(AttributeError, match=r"\.resolve\(\)"):
+    with pytest.raises(AttributeError, match=r"\.to_arrow_table\(\)"):
         wkls.us.ca.counties().filter(None)
 
 
 def test_select_raises_attribute_error():
-    with pytest.raises(AttributeError, match=r"\.resolve\(\)"):
+    with pytest.raises(AttributeError, match=r"\.to_arrow_table\(\)"):
         wkls.us.ca.counties().select("id")
 
 
 def test_group_by_raises_attribute_error():
-    with pytest.raises(AttributeError, match=r"\.resolve\(\)"):
+    with pytest.raises(AttributeError, match=r"\.to_arrow_table\(\)"):
         wkls.us.ca.counties().group_by("subtype")
 
 
 def test_arbitrary_sedona_method_raises():
-    with pytest.raises(AttributeError, match=r"\.resolve\(\)"):
+    with pytest.raises(AttributeError, match=r"\.to_arrow_table\(\)"):
         wkls.us.ca.counties().nonexistent_method()
 
 
@@ -303,22 +303,22 @@ def test_to_dicts_unchanged():
     assert all(isinstance(r, dict) for r in rows)
 
 
-# ---------- Surface 3: .resolve() escape ----------
+# ---------- Surface 3: ._resolve() escape ----------
 
 
 def test_resolve_returns_sedona_dataframe():
-    df = wkls.us.ca.counties().resolve()
+    df = wkls.us.ca.counties()._resolve()
     assert isinstance(df, sedonadb.dataframe.DataFrame)
 
 
 def test_resolve_supports_sedona_api():
-    """The object returned by .resolve() is a real sedona DataFrame.
+    """The object returned by ._resolve() is a real sedona DataFrame.
 
-    Surface 3's contract: .resolve() hands you sedona's API. We don't
+    Surface 3's contract: ._resolve() hands you sedona's API. We don't
     re-test sedona's behavior here; we just confirm the handoff works
     and users can call sedona-native methods on the result.
     """
-    df = wkls.us.ca.counties().resolve()
+    df = wkls.us.ca.counties()._resolve()
     assert isinstance(df, sedonadb.dataframe.DataFrame)
     # Call something sedona-native (not surfaced on Wkl directly).
     assert df.count() >= 1

--- a/tests/test_pythonic.py
+++ b/tests/test_pythonic.py
@@ -1,6 +1,6 @@
 """Tests for the Surface 2 Python collection protocol on ``Wkl``.
 
-Covers the v1.3.0 changes:
+Covers the v1.2.0 changes:
 
 - Collection dunders (``__len__``, ``__bool__``, ``__iter__``,
   ``__getitem__``, ``__contains__``).
@@ -13,7 +13,7 @@ Covers the v1.3.0 changes:
 - Bracket string subscript raises ``TypeError`` (was: ``DeprecationWarning``
   shim for chain access / wildcard).
 
-See the v1.3.0 release notes for the full contract this test suite
+See the v1.2.0 release notes for the full contract this test suite
 validates.
 """
 

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -214,16 +214,16 @@ def test_counties_via_name_chain():
     'IN-MAHARASHTRA' (concatenating country_iso + chain[1].upper()),
     which matched zero rows. Must equal the ISO-chain path.
     """
-    from_name = wkls.india.maharashtra.counties().count()
-    from_iso = wkls.IN.MH.counties().count()
+    from_name = len(wkls.india.maharashtra.counties())
+    from_iso = len(wkls.IN.MH.counties())
     assert from_name == from_iso
     assert from_name >= 1
 
 
 def test_cities_via_name_chain():
     """Name-based chain also supports cities() symmetrically with ISO."""
-    from_name = wkls.india.maharashtra.cities().count()
-    from_iso = wkls.IN.MH.cities().count()
+    from_name = len(wkls.india.maharashtra.cities())
+    from_iso = len(wkls.IN.MH.cities())
     assert from_name == from_iso
     assert from_name >= 1
 
@@ -274,7 +274,7 @@ def test_countries_without_region_returns_empty():
     """Countries with no regions return an empty DataFrame, not an error."""
     # Regions scope to a subtree; FK has no region rows, so this is zero
     # — not a special error case.
-    assert wkls.fk.regions().count() == 0
+    assert len(wkls.fk.regions()) == 0
 
 
 # ---------- Chain validation & error handling ----------

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -160,11 +160,11 @@ def test_numeric_region_names():
     Japan uses "Hokkaido Prefecture" as name_en, so the user must type
     the full suffix — ILIKE is not a substring match.
     """
-    df = wkls.austria.burgenland.resolve().to_arrow_table()
+    df = wkls.austria.burgenland._resolve().to_arrow_table()
     assert df.num_rows >= 1
     assert df.column("region")[0].as_py() == "AT-1"
 
-    df2 = wkls.japan.hokkaidoprefecture.resolve().to_arrow_table()
+    df2 = wkls.japan.hokkaidoprefecture._resolve().to_arrow_table()
     assert df2.num_rows >= 1
     assert df2.column("region")[0].as_py() == "JP-01"
 
@@ -186,7 +186,7 @@ def test_india_maharashtra_full_chain():
     strict=True,
 )
 def test_diacritic_english_fallback():
-    df = wkls.ivorycoast.resolve().to_arrow_table()
+    df = wkls.ivorycoast._resolve().to_arrow_table()
     assert df.num_rows >= 1
     assert df.column("country")[0].as_py() == "CI"
 
@@ -199,7 +199,7 @@ def test_diacritic_english_fallback():
     strict=True,
 )
 def test_diacritic_preserved_in_replace():
-    df = wkls.brazil.saopaulo.resolve().to_arrow_table()
+    df = wkls.brazil.saopaulo._resolve().to_arrow_table()
     assert df.num_rows >= 1
     assert df.column("region")[0].as_py() == "BR-SP"
 
@@ -281,10 +281,10 @@ def test_countries_without_region_returns_empty():
 
 
 def test_empty_chain_error():
-    """Empty chain raises on .resolve()."""
+    """Empty chain raises on ._resolve()."""
     wkl = Wkl()
     with pytest.raises(ValueError) as exc_info:
-        wkl.resolve()
+        wkl._resolve()
     assert "No attributes in the chain" in str(exc_info.value)
     assert "wkls.<country>" in str(exc_info.value)
 
@@ -292,7 +292,7 @@ def test_empty_chain_error():
 def test_chain_depth_4_is_parent_narrower():
     """Chain depth 4 narrows by parent_id."""
     # Adams County in PA has a Franklin township — single match.
-    assert wkls.us.pa.adamscounty.franklin.resolve().count() == 1
+    assert wkls.us.pa.adamscounty.franklin._resolve().count() == 1
 
 
 def test_too_many_chained_attributes():
@@ -304,7 +304,7 @@ def test_too_many_chained_attributes():
 def test_nonexistent_location_returns_empty():
     """Unknown identifiers return empty DataFrames, not exceptions."""
     # ZZ is not a valid country code
-    assert wkls.zz.resolve().count() == 0
+    assert wkls.zz._resolve().count() == 0
 
     # ZZ is not a valid US state code
-    assert wkls.us.zz.resolve().count() == 0
+    assert wkls.us.zz._resolve().count() == 0

--- a/tests/test_to_arrow_table.py
+++ b/tests/test_to_arrow_table.py
@@ -92,3 +92,10 @@ def test_roundtrip_geopandas():
     gdf = gpd.GeoDataFrame.from_arrow(tbl)
     assert gdf.geometry.notna().any()
     assert len(gdf) == len(tbl)
+
+
+def test_no_string_view_columns():
+    """String columns are utf8, not utf8_view (pyarrow.compute compat)."""
+    tbl = wkls.us.ca.counties().to_arrow_table()
+    for field in tbl.schema:
+        assert field.type != pa.string_view(), f"{field.name} is string_view"

--- a/tests/test_to_arrow_table.py
+++ b/tests/test_to_arrow_table.py
@@ -1,0 +1,94 @@
+"""Tests for ``Wkl.to_arrow_table()`` — Surface 3 escape hatch.
+
+Covers chain-mode (direct Overture query) and result-mode (IN-list
+fallback) paths, schema validation, GeoArrow encoding, and edge cases.
+"""
+
+import pyarrow as pa
+import pytest
+
+import wkls
+
+
+def test_chain_mode_returns_pyarrow_table():
+    """wkls.us.ca.cities().to_arrow_table() returns pa.Table."""
+    tbl = wkls.us.ca.cities().to_arrow_table()
+    assert isinstance(tbl, pa.Table)
+    assert len(tbl) > 0
+
+
+def test_chain_mode_has_geometry_column():
+    """Geometry column exists and is GeoArrow WKB extension type."""
+    tbl = wkls.us.ca.cities().to_arrow_table()
+    assert "geometry" in tbl.schema.names
+    geom_field = tbl.schema.field("geometry")
+    # Extension type name contains 'geoarrow.wkb'
+    assert "geoarrow.wkb" in str(geom_field.type)
+
+
+def test_chain_mode_has_metadata_columns():
+    """All expected metadata columns present."""
+    tbl = wkls.us.ca.cities().to_arrow_table()
+    expected = {
+        "id",
+        "country",
+        "region",
+        "subtype",
+        "name_primary",
+        "name_en",
+        "parent_id",
+        "geometry",
+    }
+    assert expected <= set(tbl.schema.names)
+
+
+def test_chain_mode_correct_crs():
+    """GeoArrow column has OGC:CRS84 CRS metadata."""
+    tbl = wkls.us.ca.cities().to_arrow_table()
+    geom_field = tbl.schema.field("geometry")
+    # CRS is encoded in the extension metadata
+    assert (
+        "CRS84" in str(geom_field.metadata)
+        or "CRS84" in str(geom_field.type)
+        or "CRS84" in repr(geom_field.type)
+    )
+
+
+def test_result_mode_from_cities():
+    """Result-mode Wkl (from .cities()) produces valid table."""
+    cities = wkls.us.ca.cities()
+    _ = list(cities)  # force result-mode
+    tbl = cities.to_arrow_table()
+    assert isinstance(tbl, pa.Table)
+    assert "geometry" in tbl.schema.names
+
+
+def test_result_mode_from_search():
+    """Result-mode from .search() works."""
+    tbl = wkls.search("san francisco").to_arrow_table()
+    assert isinstance(tbl, pa.Table)
+    assert len(tbl) > 0
+
+
+def test_empty_result_returns_empty_table_with_schema():
+    """Chain that matches 0 rows → empty table, correct schema."""
+    tbl = wkls.us.ca.search("xyznonexistent999").to_arrow_table()
+    assert isinstance(tbl, pa.Table)
+    assert len(tbl) == 0
+    assert "geometry" in tbl.schema.names
+
+
+def test_root_wkl_raises_valueerror():
+    """to_arrow_table() on root Wkl raises ValueError."""
+    with pytest.raises(ValueError):
+        wkls.Wkl().to_arrow_table()
+
+
+def test_roundtrip_geopandas():
+    """GeoPandas round-trip produces valid GeoDataFrame."""
+    gpd = pytest.importorskip("geopandas")
+
+    tbl = wkls.us.ca.cities().to_arrow_table()
+    gdf = gpd.GeoDataFrame.from_arrow(tbl)
+    assert gdf.geometry.notna().any()
+    assert len(gdf) == len(tbl)

--- a/wkls/__init__.py
+++ b/wkls/__init__.py
@@ -44,10 +44,21 @@ so 'san francisco' / 'San Francisco' / 'sanfrancisco' all match.
     wkls.us.tn.search('franklin')          # Franklins in Tennessee only
     wkls.search('franklin')                # global — 125+ rows, use sparingly
 
-Every call returns a Wkl — one unified type. Inspect with .count(),
-.head(), .to_arrow_table(), or .to_dicts() for a plain list-of-dicts
-that's easy to iterate / filter in Python. Extract geometry with
-.wkt() / .wkb() / .geojson() when the Wkl holds exactly one row.
+Every call returns a Wkl — one unified type. Inspect like any Python
+sequence:
+
+    len(wkl)                               # row count
+    for row in wkl: row.wkt()              # iterate; each row is a Wkl
+    wkl[0], wkl[-1]                        # positional index
+    wkl[:5]                                # slice; returns a multi-row Wkl
+    '<uuid>' in wkl                        # id-column membership check
+    list(wkl), tuple(wkl)                  # standard collection conversions
+
+Also available: .count(), .head(n), .limit(n), .to_dicts(),
+.to_arrow_table(), .show(). For DataFrame ops beyond admin-boundary
+lookup (.filter, .join, .group_by, …), call .resolve() to drop to the
+underlying SedonaDB DataFrame. Extract geometry with .wkt() / .wkb() /
+.geojson() when the Wkl holds exactly one row.
 
 Navigation — .parent walks up one level; .path returns the canonical
 dot-chain string that round-trips via eval:

--- a/wkls/__init__.py
+++ b/wkls/__init__.py
@@ -81,6 +81,24 @@ Two ways to use the library (equivalent):
     >>> from wkls import Wkl               # explicit instantiation
     >>> wkl = Wkl()
     >>> wkl.us.ca.sanfrancisco.wkt()
+
+Configuration — wkls defaults to the latest Overture Maps release:
+
+    wkls.overture_releases()               # list available versions
+    wkls.overture_version()                # current version string
+    wkls.configure(overture_version='2026-03-18.0')
+    WKLS_OVERTURE_VERSION=2026-03-18.0     # env var, checked at import
+
+Arrow schema — wkl.to_arrow_table() returns these columns:
+
+    id            string     Overture feature ID (UUID)
+    country       string     ISO 3166-1 alpha-2 code
+    region        string     region name (state / province)
+    subtype       string     country | dependency | region | county | locality | localadmin
+    name_primary  string     primary display name
+    name_en       string     English name (may equal name_primary)
+    parent_id     string     parent feature ID
+    geometry      GeoArrow WKB (OGC:CRS84)
 """
 
 from __future__ import annotations

--- a/wkls/__init__.py
+++ b/wkls/__init__.py
@@ -54,11 +54,11 @@ sequence:
     '<uuid>' in wkl                        # id-column membership check
     list(wkl), tuple(wkl)                  # standard collection conversions
 
-Also available: .count(), .head(n), .limit(n), .to_dicts(),
-.to_arrow_table(), .show(). For DataFrame ops beyond admin-boundary
-lookup (.filter, .join, .group_by, …), call .resolve() to drop to the
-underlying SedonaDB DataFrame. Extract geometry with .wkt() / .wkb() /
-.geojson() when the Wkl holds exactly one row.
+Also available: .to_dicts() (metadata-only), .to_arrow_table() (with
+geometry, GeoArrow WKB). For DataFrame ops beyond admin-boundary lookup
+(.filter, .join, .group_by, …), call .to_arrow_table() and use your
+engine of choice (GeoPandas, DuckDB, Polars, etc.). Extract geometry
+with .wkt() / .wkb() / .geojson() when the Wkl holds exactly one row.
 
 Navigation — .parent walks up one level; .path returns the canonical
 dot-chain string that round-trips via eval:
@@ -86,7 +86,6 @@ Two ways to use the library (equivalent):
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
-from typing import Any
 
 from .core import Wkl
 
@@ -132,7 +131,7 @@ _REMOVED: dict[str, str] = {
 }
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> Wkl:
     if name.startswith("_"):
         raise AttributeError(f"module 'wkls' has no attribute {name!r}")
     if name in _REMOVED:

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1818,7 +1818,15 @@ class Wkl:
             wkb_col = wkb_col.cast(pa.binary())
 
         geo_col = ga.with_crs(wkb_col, crs=ga.OGC_CRS84)
-        return tbl.set_column(geom_idx, "geometry", geo_col)
+        tbl = tbl.set_column(geom_idx, "geometry", geo_col)
+
+        # SedonaDB returns string_view columns; many pyarrow.compute
+        # kernels don't support string_view yet, so cast to string.
+        for i, field in enumerate(tbl.schema):
+            if field.type == pa.string_view():
+                tbl = tbl.set_column(i, field.name, tbl.column(i).cast(pa.string()))
+
+        return tbl
 
     def __arrow_c_array__(self, requested_schema=None):
         """Implement the Arrow PyCapsule protocol

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -726,12 +726,8 @@ class Wkl:
                     )
         else:
             # Same attr + same parent (or no chain to narrow) — dot
-            # paths can't distinguish these. by_id is the only way.
-            lines.append(
-                f"{n} matches for '{where}'. No dot-access narrower "
-                "distinguishes these — use by_id:"
-            )
-            lines.append("")
+            # paths can't distinguish these.
+            lines.append(f"{n} matches for '{where}'. Narrow with one of:")
 
         # Subtype narrowing — applies whenever candidates span multiple
         # subtype *groups* (two rows both in ``locality`` don't get a

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -335,11 +335,52 @@ _DIR_REGION_METHODS = frozenset(
 _DIR_CITY_METHODS = frozenset({"geojson", "parent", "path", "wkb", "wkt"})
 
 # Result-mode: DataFrame passthroughs that make sense to surface on a
-# multi-row Wkl. Keep this to the common inspection verbs — sedona's
-# DataFrame has a wider surface but listing everything would be noise.
-_DIR_DATAFRAME_METHODS = frozenset(
-    {"count", "head", "limit", "show", "to_arrow_table", "to_dicts"}
-)
+# Redirect tables — priority: S1 > S2 > S3.
+# Checked in order by __getattr__; first match wins.
+_S1_REDIRECTS: dict[str, str] = {
+    "filter": (
+        "To find locations by name, use 'wkl.search(\"query\")'. "
+        "For arbitrary column filters, use 'wkl.to_arrow_table()' "
+        "and your engine of choice."
+    ),
+    "where": (
+        "To find locations by name, use 'wkl.search(\"query\")'. "
+        "For arbitrary column filters, use 'wkl.to_arrow_table()' "
+        "and your engine of choice."
+    ),
+    "query": (
+        "To find locations by name, use 'wkl.search(\"query\")'. "
+        "For arbitrary column filters, use 'wkl.to_arrow_table()' "
+        "and your engine of choice."
+    ),
+    "resolve": "Renamed in v1.2.0. Use 'wkl.to_arrow_table()'.",
+}
+
+_S2_REDIRECTS: dict[str, str] = {
+    "count": "Use 'len(wkl)'.",
+    "head": "Use 'wkl[:n]'.",
+    "limit": "Use 'wkl[:n]'.",
+    "take": "Use 'wkl[:n]'.",
+    "show": "Use 'wkl[:n]'.",
+    "collect": "Use 'list(wkl)'.",
+    "to_pylist": "Use 'list(wkl)'.",
+}
+
+_S3_REDIRECTS: dict[str, str] = {
+    "select": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "with_columns": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "join": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "group_by": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "agg": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "sort": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "order_by": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "to_pandas": "Use 'wkl.to_arrow_table().to_pandas()'.",
+    "to_geopandas": "Use 'gpd.GeoDataFrame.from_arrow(wkl.to_arrow_table())'.",
+    "to_polars": "Use 'pl.from_arrow(wkl.to_arrow_table())'.",
+    "to_arrow": "Use 'wkl.to_arrow_table()' (the public name follows SedonaDB/DuckDB convention).",
+}
+
+_GENERIC_FALLBACK = "Use 'wkl.to_arrow_table()' and your engine of choice."
 
 # Listing methods that narrow a multi-row result to a single subtype
 # (or inspect what subtypes are present). Surfaced via ``dir()`` on a
@@ -515,7 +556,7 @@ class Wkl:
         self._country_iso: str = ""
         # Cache of the resolved Arrow table for Surface 2 dunders. Populated
         # lazily on first ``_materialize()`` call; safe because ``Wkl`` is
-        # immutable (no re-resolve path in v1.3).
+        # immutable (no re-resolve path in v1.2).
         self._arrow_table: pa.Table | None = None
         if not self.chain:
             return
@@ -975,25 +1016,23 @@ class Wkl:
         ).to_view("overture", overwrite=True)
         _overture_view_loaded = True
 
-    def __getattr__(self, attr: str) -> Any:
-        """Handle attribute access.
+    def __getattr__(self, attr: str) -> Wkl:
+        """Handle attribute access — chain drill or redirect.
 
-        Three behaviors, picked by mode:
+        Two behaviors:
 
-        - **Root / chain-mode**: drill one level deeper into the admin
-          hierarchy (``wkls.us.ca.sanfrancisco``). Raises ``ValueError``
-          past chain depth 3.
-        - **Result-mode** (empty chain, cached DataFrame — e.g. after
-          ``.search(...)`` or ``.countries()``): forward to the cached
-          DataFrame so callers can do ``.count()``, ``.to_arrow_table()``,
-          ``.head(n)``, etc. Location-name drill doesn't apply here —
-          the result set has no tree position.
+        - **Chain drill** (valid location identifier): drill one level
+          deeper into the admin hierarchy
+          (``wkls.us.ca.sanfrancisco``).
+        - **Redirect**: any attribute that isn't a valid location
+          identifier raises ``AttributeError`` with a priority-ordered
+          suggestion (Surface 1 → Surface 2 → Surface 3).
 
         Raises:
-            AttributeError: For private/dunder attributes, or in
-                result-mode when the attribute isn't found on the
-                cached DataFrame.
-            ValueError: If chain depth would exceed 3.
+            AttributeError: For private/dunder attributes, root-only
+                methods, redirect-table matches, or any unknown
+                attribute.
+            ValueError: If chain depth would exceed 4.
         """
         # Don't intercept private/dunder attributes - raise AttributeError
         if attr.startswith("_"):
@@ -1009,38 +1048,42 @@ class Wkl:
                 f"'{self.__class__.__name__}' object has no attribute '{attr}'"
             )
 
-        # Result-mode: allow-listed DataFrame verbs only. Head/limit wrap
-        # their return in a Wkl so chaining continues (fixes the
-        # .head(3).to_dicts() usability trap); the rest pass through
-        # unchanged. Anything outside the allowlist raises with a
-        # pointer at .resolve() — the documented Surface 3 escape hatch.
-        if not self.chain and self._df is not None:
-            if attr in _DIR_DATAFRAME_METHODS:
-                if attr in ("head", "limit"):
-                    return _wrapped_subset_method(self, attr)
-                return getattr(self._df, attr)
-            raise AttributeError(_passthrough_error(attr))
+        # Chain drill: only attempt for names that could be location
+        # identifiers (alphanumeric). Result-mode Wkls (no chain, have
+        # _df) skip drill — they have no tree position.
+        if self.chain or self._df is None:
+            if attr.isalnum():
+                new_chain = self.chain + [attr.lower()]
+                if len(new_chain) > 4:
+                    raise ValueError(
+                        "Chain too deep (max = 4). Use .by_id('<uuid>') for specific rows."
+                    )
 
-        new_chain = self.chain + [attr.lower()]
-        if len(new_chain) > 4:
-            raise ValueError(
-                "Chain too deep (max = 4). Use .by_id('<uuid>') for specific rows."
-            )
+                # Depth 4: parent-narrower. The preceding 3-level chain must
+                # resolve to exactly one row.
+                if len(new_chain) == 4:
+                    df = self._df if self._df is not None else self._resolve()
+                    count = df.count()
+                    if count != 1:
+                        raise ValueError(
+                            "4-level chain requires the preceding chain to resolve to a "
+                            f"single row; '{'.'.join(self.chain)}' has {count} rows."
+                        )
+                    parent_row = df.head(1).to_arrow_table()
+                    parent_id = parent_row.column("id")[0].as_py()
+                    return Wkl(new_chain, _parent_id=parent_id)
+                return Wkl(new_chain)
 
-        # Depth 4: parent-narrower. The preceding 3-level chain must resolve
-        # to exactly one row; we use that row's id to filter children.
-        if len(new_chain) == 4:
-            df = self._df if self._df is not None else self._resolve()
-            count = df.count()
-            if count != 1:
-                raise ValueError(
-                    "4-level chain requires the preceding chain to resolve to a "
-                    f"single row; '{'.'.join(self.chain)}' has {count} rows."
+        # Not a location name → redirect with priority.
+        for table in (_S1_REDIRECTS, _S2_REDIRECTS, _S3_REDIRECTS):
+            if attr in table:
+                raise AttributeError(
+                    f"'{attr}' is not part of the Wkl API. {table[attr]}"
                 )
-            parent_row = df.head(1).to_arrow_table()
-            parent_id = parent_row.column("id")[0].as_py()
-            return Wkl(new_chain, _parent_id=parent_id)
-        return Wkl(new_chain)
+
+        raise AttributeError(
+            f"'{attr}' is not part of the Wkl API. {_GENERIC_FALLBACK}"
+        )
 
     def __dir__(self) -> list[str]:
         """Return contextually valid attributes for this ``Wkl``.
@@ -1087,7 +1130,7 @@ class Wkl:
         """
         assert self._df is not None
         row_count = self._df.count()
-        base = set(_DIR_DATAFRAME_METHODS)
+        base = {"to_arrow_table", "to_dicts"}
         if row_count == 0:
             return base
         if row_count == 1:
@@ -1135,7 +1178,7 @@ class Wkl:
     # Wkl implements collections.abc.Sequence on the rows of the resolved
     # result set. Backed by a cached pyarrow Table (_arrow_table) so that
     # len/iter/getitem avoid a sedona round-trip per call. The old bracket
-    # access shim (pre-v1.3 DeprecationWarning) is replaced by the new
+    # access shim (pre-v1.2 DeprecationWarning) is replaced by the new
     # protocol — string subscripts now raise TypeError with a pointer at
     # dot access / .search() / .resolve().
 
@@ -1692,8 +1735,6 @@ class Wkl:
             >>> import duckdb
             >>> duckdb.from_arrow(tbl)
         """
-        import geoarrow.pyarrow as ga  # noqa: F811
-
         _ensure_overture_loaded()
 
         if self._df is not None:
@@ -2161,31 +2202,3 @@ def _wkl_from_arrow_slice(table: pa.Table) -> Wkl:
     ``_df`` for downstream ``.wkt()`` / ``.path`` / ``.parent`` calls.
     """
     return Wkl(_df=sedona.create_data_frame(table))
-
-
-
-def _wrapped_subset_method(wkl: Wkl, name: str) -> Callable[..., Wkl]:
-    """Return a wrapper around ``df.head`` / ``df.limit`` that returns a ``Wkl``.
-
-    Fixes the ``.head(n).to_dicts()`` usability trap: ``.to_dicts()`` is a
-    ``Wkl`` method, so the inner subset call must return a ``Wkl`` for
-    the chain to type-check end-to-end.
-    """
-    sedona_method = getattr(wkl._df, name)
-
-    def _call(*args: Any, **kwargs: Any) -> Wkl:
-        sub_df = sedona_method(*args, **kwargs)
-        return Wkl(_df=sub_df)
-
-    _call.__name__ = name
-    _call.__qualname__ = f"Wkl.{name}"
-    return _call
-
-
-def _passthrough_error(attr: str) -> str:
-    """Format the AttributeError message for the narrowed __getattr__ passthrough."""
-    return (
-        f"'Wkl' object has no attribute {attr!r}. "
-        f"For DataFrame operations beyond admin-boundary lookup, call "
-        f".to_arrow_table() to get a PyArrow Table."
-    )

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -362,7 +362,7 @@ _STR_SUBSCRIPT_MSG = (
     "  - For chain drill: use dot access — wkls.us.ca.sanfrancisco\n"
     "  - For name search: use .search() — wkls.us.search('francisco')\n"
     "  - For a specific row's column: use .to_dicts() and index the dict\n"
-    "  - For arbitrary DataFrame ops: call .resolve() to drop to sedona"
+    "  - For arbitrary DataFrame ops: call .to_arrow_table() and use your engine of choice"
 )
 
 
@@ -793,7 +793,7 @@ class Wkl:
             return "wkls"
 
         # Result-mode: must be a single row to have a single canonical path.
-        row_count = self.resolve().count()
+        row_count = self._resolve().count()
         if row_count != 1:
             raise ValueError(
                 f".path requires a single-row Wkl; this one has {row_count} rows."
@@ -801,7 +801,7 @@ class Wkl:
 
         # Walk up parent_id collecting chain attributes. Names are
         # normalized to lowercase + no whitespace, matching __getattr__.
-        table = self.resolve().head(1).to_arrow_table()
+        table = self._resolve().head(1).to_arrow_table()
         row = {col: table.column(col)[0].as_py() for col in table.column_names}
         parts: list[str] = []
         # At most 4 hops (country → region → city). Defensive cap in case
@@ -838,7 +838,7 @@ class Wkl:
         # attribute lookup protocol treats that as "attribute doesn't exist"
         # and falls through to __getattr__, which would drill "parent" as
         # a location name and return an empty Wkl. Use ValueError.
-        df = self.resolve()
+        df = self._resolve()
         row_count = df.count()
         if row_count != 1:
             raise ValueError(
@@ -1030,7 +1030,7 @@ class Wkl:
         # Depth 4: parent-narrower. The preceding 3-level chain must resolve
         # to exactly one row; we use that row's id to filter children.
         if len(new_chain) == 4:
-            df = self._df if self._df is not None else self.resolve()
+            df = self._df if self._df is not None else self._resolve()
             count = df.count()
             if count != 1:
                 raise ValueError(
@@ -1146,7 +1146,7 @@ class Wkl:
         round-trips on the same ``Wkl``. Immutable after first call.
         """
         if self._arrow_table is None:
-            self._arrow_table = self.resolve().to_arrow_table()
+            self._arrow_table = self._resolve().to_arrow_table()
         return self._arrow_table
 
     def __len__(self) -> int:
@@ -1246,7 +1246,7 @@ class Wkl:
         if step != 1:
             raise TypeError(
                 f"Wkl does not support sliced steps (got step={step}). "
-                "Call .resolve() for arbitrary DataFrame slicing."
+                "Call .to_arrow_table() for arbitrary DataFrame slicing."
             )
         length = max(0, stop - start)
         return _wkl_from_arrow_slice(table.slice(start, length))
@@ -1293,7 +1293,7 @@ class Wkl:
         if not self.chain and self._df is None:
             return "Wkl(root)"
 
-        base_repr = repr(self.resolve())
+        base_repr = repr(self._resolve())
         header = self._repr_header()
 
         if self.chain:
@@ -1347,7 +1347,7 @@ class Wkl:
         ``__repr__`` never throws.
         """
         try:
-            df = self._df if self._df is not None else self.resolve()
+            df = self._df if self._df is not None else self._resolve()
             df.to_view("_wkls_repr_subtypes", overwrite=True)
             tbl = sedona.sql(
                 "SELECT subtype, COUNT(*) AS n FROM _wkls_repr_subtypes "
@@ -1360,27 +1360,19 @@ class Wkl:
         except Exception:
             return {}
 
-    def resolve(self) -> sedonadb.dataframe.DataFrame:
-        """Resolve the location chain to a DataFrame.
+    def _build_query(self) -> tuple[str, dict[str, str]]:
+        """Return (query_template, params) for the current chain.
 
-        Idempotent: returns ``self._df`` if already populated (by a
-        prior ``resolve()`` on this instance, or explicitly by
-        listing/search methods in result-mode). Otherwise executes the
-        appropriate SQL query based on the chain depth.
-
-        Returns:
-            DataFrame containing matching location records.
+        Does NOT execute the query. Does NOT set ``self._df``.
+        Caller is responsible for formatting and executing the query.
 
         Raises:
-            ValueError: If the chain is empty and no cached DataFrame
-                is available (i.e., called on a root ``Wkl``).
+            ValueError: If chain is empty.
         """
-        if self._df is not None:
-            return self._df
-
         if not self.chain:
             raise ValueError(
-                "No attributes in the chain. Use wkls.<country> or wkls.<country>.<region>, etc."
+                "No attributes in the chain. Use wkls.<country> or "
+                "wkls.<country>.<region>, etc."
             )
 
         params: dict[str, str] = {}
@@ -1408,22 +1400,37 @@ class Wkl:
             params["region"] = self._region_iso
             params["city"] = self.chain[2]
 
-        # Depth 4: parent-narrower. Filter by parent_id of the resolved
-        # depth-3 row (passed in via __init__ _parent_id).
         if len(self.chain) > 3:
             if not self._parent_id:
                 raise ValueError(
                     "4-level chain requires a resolved parent_id; "
                     "construct via __getattr__ so the parent is known."
                 )
-            self._df = sedona.sql(
-                queries.CHILDREN_BY_PARENT.format(
-                    parent_id=sqlescape(self._parent_id),
-                    name=sqlescape(self.chain[3]),
-                )
-            )
+            query = queries.CHILDREN_BY_PARENT
+            params["parent_id"] = self._parent_id
+            params["name"] = self.chain[3]
+
+        return query, params
+
+    def _resolve(self) -> sedonadb.dataframe.DataFrame:
+        """Resolve the location chain to a SedonaDB DataFrame.
+
+        Idempotent: returns ``self._df`` if already populated (by a
+        prior ``_resolve()`` on this instance, or explicitly by
+        listing/search methods in result-mode). Otherwise executes the
+        appropriate SQL query based on the chain depth.
+
+        Returns:
+            DataFrame containing matching location records.
+
+        Raises:
+            ValueError: If the chain is empty and no cached DataFrame
+                is available (i.e., called on a root ``Wkl``).
+        """
+        if self._df is not None:
             return self._df
 
+        query, params = self._build_query()
         self._df = sedona.sql(
             query.format(**{k: sqlescape(v) for k, v in params.items()})
         )
@@ -1544,7 +1551,7 @@ class Wkl:
                 registered (first geometry call only; requires S3 access).
         """
         _ensure_overture_loaded()
-        df = self.resolve()
+        df = self._resolve()
         row_count = df.count()
         if row_count == 0:
             # Chain-mode empty: fall back to the "Did you mean?" hint.
@@ -1647,7 +1654,7 @@ class Wkl:
             ...     if r["country"] != "US"
             ... ]
         """
-        return self.resolve().to_arrow_table().to_pylist()
+        return self._resolve().to_arrow_table().to_pylist()
 
     def __arrow_c_array__(self, requested_schema=None):
         """Implement the Arrow PyCapsule protocol
@@ -1836,7 +1843,7 @@ class Wkl:
         # matches. This keeps the pattern consistent with depth 1-2
         # (where ``regions()`` at region level returns the region row
         # itself) — the current row is in-scope for its own subtype.
-        df = self.resolve()
+        df = self._resolve()
         row_count = df.count()
         if row_count != 1:
             raise ValueError(
@@ -1936,7 +1943,7 @@ class Wkl:
 
         # Depth >= 3: scope is self + descendants (same semantics as
         # counties()/cities() past region level).
-        df = self.resolve()
+        df = self._resolve()
         row_count = df.count()
         if row_count != 1:
             raise ValueError(
@@ -2063,5 +2070,5 @@ def _passthrough_error(attr: str) -> str:
     return (
         f"'Wkl' object has no attribute {attr!r}. "
         f"For DataFrame operations beyond admin-boundary lookup, call "
-        f".resolve() to escape to SedonaDB: wkl.resolve().{attr}(...)"
+        f".to_arrow_table() to get a PyArrow Table."
     )

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -24,8 +24,10 @@ import os
 import re
 import urllib.request
 import xml.etree.ElementTree as ET
+from collections.abc import Iterator
 from typing import Any, Callable
 
+import pyarrow as pa
 import sedonadb
 import sqlescapy
 
@@ -347,6 +349,22 @@ _DIR_RESULT_NARROW_METHODS = frozenset(
     {"cities", "counties", "countries", "dependencies", "regions", "subtypes"}
 )
 
+# Surface 2 error messages. Kept at module scope so tests can pattern-match
+# a stable substring without coupling to the exact full text.
+_ROOT_NO_ROWS_MSG = (
+    "Root Wkl has no rows to inspect. Use dot access "
+    "(wkls.us, wkls.india.maharashtra) or a listing/search method "
+    "(wkls.countries(), wkls.us.search('...')) to produce a result first."
+)
+
+_STR_SUBSCRIPT_MSG = (
+    "Wkl does not support string subscript access.\n"
+    "  - For chain drill: use dot access — wkls.us.ca.sanfrancisco\n"
+    "  - For name search: use .search() — wkls.us.search('francisco')\n"
+    "  - For a specific row's column: use .to_dicts() and index the dict\n"
+    "  - For arbitrary DataFrame ops: call .resolve() to drop to sedona"
+)
+
 
 def _normalize_name(name: str | None) -> str:
     """Lowercase + strip non-alphanumerics. Matches ``__getattr__`` input form."""
@@ -409,6 +427,20 @@ class Wkl:
     Example:
         >>> import wkls
         >>> wkls.us.ca.sanfrancisco.wkt()
+
+    Python collection protocol (Surface 2) — ``Wkl`` implements
+    ``collections.abc.Sequence`` on the rows of the resolved result:
+
+    - ``len(wkl)``         row count
+    - ``bool(wkl)``        True iff non-empty
+    - ``for row in wkl``   iterate; each row is itself a single-row Wkl
+    - ``wkl[i]``           positional index; supports negatives
+    - ``wkl[a:b]``         slice; returns a multi-row Wkl
+    - ``uuid in wkl``      membership check against the ``id`` column
+
+    Iteration is backed by a cached pyarrow Table — no SQL per row. For
+    DataFrame operations outside admin-boundary lookup (``.filter``,
+    ``.join``, ``.group_by``, …), call ``.resolve()``.
     """
 
     _has_region: bool = True
@@ -481,6 +513,10 @@ class Wkl:
         self._df: sedonadb.dataframe.DataFrame | None = _df
         self._parent_id: str | None = _parent_id
         self._country_iso: str = ""
+        # Cache of the resolved Arrow table for Surface 2 dunders. Populated
+        # lazily on first ``_materialize()`` call; safe because ``Wkl`` is
+        # immutable (no re-resolve path in v1.3).
+        self._arrow_table: pa.Table | None = None
         if not self.chain:
             return
 
@@ -973,14 +1009,17 @@ class Wkl:
                 f"'{self.__class__.__name__}' object has no attribute '{attr}'"
             )
 
-        # Result-mode: pass through to the cached DataFrame so standard
-        # ops (count, to_arrow_table, head, show, …) keep working.
+        # Result-mode: allow-listed DataFrame verbs only. Head/limit wrap
+        # their return in a Wkl so chaining continues (fixes the
+        # .head(3).to_dicts() usability trap); the rest pass through
+        # unchanged. Anything outside the allowlist raises with a
+        # pointer at .resolve() — the documented Surface 3 escape hatch.
         if not self.chain and self._df is not None:
-            if hasattr(self._df, attr):
+            if attr in _DIR_DATAFRAME_METHODS:
+                if attr in ("head", "limit"):
+                    return _wrapped_subset_method(self, attr)
                 return getattr(self._df, attr)
-            raise AttributeError(
-                f"'{self.__class__.__name__}' object has no attribute '{attr}'"
-            )
+            raise AttributeError(_passthrough_error(attr))
 
         new_chain = self.chain + [attr.lower()]
         if len(new_chain) > 4:
@@ -1091,59 +1130,149 @@ class Wkl:
                 result.add(name)
         return sorted(result)
 
-    def __getitem__(self, key: Any) -> Wkl | sedonadb.dataframe.DataFrame:
-        """[Deprecated] Handle bracket access for location chaining.
+    # --- Surface 2: Python collection protocol ------------------------------
+    #
+    # Wkl implements collections.abc.Sequence on the rows of the resolved
+    # result set. Backed by a cached pyarrow Table (_arrow_table) so that
+    # len/iter/getitem avoid a sedona round-trip per call. The old bracket
+    # access shim (pre-v1.3 DeprecationWarning) is replaced by the new
+    # protocol — string subscripts now raise TypeError with a pointer at
+    # dot access / .search() / .resolve().
 
-        Emits a :class:`DeprecationWarning` pointing at the modern API:
+    def _materialize(self) -> pa.Table:
+        """Resolve and materialize rows as a pyarrow Table, caching the result.
 
-        - For name-based access, use dot notation: ``wkls.india`` instead of
-          ``wkls["IN"]``, ``wkls.us.oregon`` instead of ``wkls.us["OR"]``.
-        - For wildcard search, use :meth:`search`: ``wkls.us.ca.search("fran")``
-          instead of ``wkls.us.ca["%fran%"]``.
-
-        DataFrame-style indexing (list / slice keys) is unaffected —
-        it passes through to the cached DataFrame and does not warn.
-
-        The shim is preserved for backward compatibility and will be
-        removed in a future major version.
+        All Surface 2 dunders go through this to avoid multiple sedona
+        round-trips on the same ``Wkl``. Immutable after first call.
         """
-        import warnings
+        if self._arrow_table is None:
+            self._arrow_table = self.resolve().to_arrow_table()
+        return self._arrow_table
 
-        # DataFrame-style passthrough: list or slice keys operate on
-        # the cached DataFrame (result-mode or chain-mode).
-        if isinstance(key, (list, slice)):
-            df = self.resolve() if self._df is None else self._df
-            return df[key]
+    def __len__(self) -> int:
+        """Number of rows in the resolved result.
 
-        key_str = str(key)
-        if "%" in key_str:
-            cleaned = key_str.strip("%")
-            warnings.warn(
-                "Bracket access with wildcards is deprecated; "
-                f"use .search({cleaned!r}) instead.",
-                DeprecationWarning,
-                stacklevel=2,
+        Raises:
+            TypeError: If called on a root ``Wkl`` (no chain, no ``_df``).
+        """
+        try:
+            return self._materialize().num_rows
+        except ValueError as e:
+            raise TypeError(_ROOT_NO_ROWS_MSG) from e
+
+    def __bool__(self) -> bool:
+        """True iff the resolved result has at least one row.
+
+        Raises:
+            TypeError: If called on a root ``Wkl`` (no chain, no ``_df``).
+        """
+        return len(self) > 0
+
+    def __iter__(self) -> Iterator[Wkl]:
+        """Yield one single-row ``Wkl`` per row in the resolved result.
+
+        Each yielded ``Wkl`` is result-mode with ``_df`` set to a one-row
+        slice of the parent's Arrow table, rewrapped via
+        ``sedona.create_data_frame``. No SQL round-trip per step.
+
+        Raises:
+            TypeError: If called on a root ``Wkl``. Raised eagerly at
+                ``iter()`` call time (not deferred to the first
+                ``next()``) so callers see the error at the binding
+                site.
+        """
+        # Materialize eagerly so a root-Wkl TypeError surfaces at
+        # iter() call time, matching user expectation. A plain generator
+        # function would defer the raise to the first .__next__().
+        try:
+            table = self._materialize()
+        except ValueError as e:
+            raise TypeError(_ROOT_NO_ROWS_MSG) from e
+
+        def _gen() -> Iterator[Wkl]:
+            for i in range(table.num_rows):
+                yield _wkl_from_arrow_slice(table.slice(i, 1))
+
+        return _gen()
+
+    def __getitem__(self, key: int | slice) -> Wkl:
+        """Index or slice into the resolved result set.
+
+        Args:
+            key: ``int`` (supports negatives) for a single-row ``Wkl``, or
+                ``slice`` (step must be 1) for a multi-row ``Wkl``.
+
+        Raises:
+            TypeError: If ``key`` is not ``int`` or ``slice``. String keys
+                point at dot access / ``.search()`` / ``.resolve()`` (see
+                ``_STR_SUBSCRIPT_MSG``). Sliced steps other than 1 are
+                rejected with a pointer at ``.resolve()``.
+            IndexError: If an ``int`` key is outside ``[-len, len)``.
+            TypeError: If called on a root ``Wkl`` (no chain, no ``_df``).
+        """
+        # Type-check the key BEFORE resolving, so that string / list keys
+        # on a root Wkl get the specific bracket-removal message rather
+        # than the generic "root Wkl has no rows" one.
+        if isinstance(key, str):
+            raise TypeError(_STR_SUBSCRIPT_MSG)
+
+        if isinstance(key, bool):
+            # bool is a subclass of int in Python; reject to avoid
+            # wkl[True] silently being wkl[1].
+            raise TypeError(
+                f"Wkl indices must be int or slice, got {type(key).__name__}"
             )
-        else:
-            chain_prefix = ".".join(self.chain) + "." if self.chain else ""
-            warnings.warn(
-                "Bracket access is deprecated; "
-                f"use dot access (wkls.{chain_prefix}{key_str.lower()}) or the "
-                "corresponding name form.",
-                DeprecationWarning,
-                stacklevel=2,
+
+        if not isinstance(key, (int, slice)):
+            raise TypeError(
+                f"Wkl indices must be int or slice, got {type(key).__name__}"
             )
 
-        new_chain = self.chain + [key_str.lower()]
-        if len(new_chain) > 3 and "%" not in key_str:
-            raise ValueError("Too many chained attributes (max = 3)")
-        # Wildcard pattern: return the raw DataFrame for back-compat.
-        if "%" in key_str:
-            return Wkl(new_chain).resolve()
+        try:
+            table = self._materialize()
+        except ValueError as e:
+            raise TypeError(_ROOT_NO_ROWS_MSG) from e
 
-        new_wkl = Wkl(new_chain)
-        new_wkl._df = new_wkl.resolve()
-        return new_wkl
+        if isinstance(key, int):
+            n = table.num_rows
+            idx = key + n if key < 0 else key
+            if idx < 0 or idx >= n:
+                raise IndexError(f"Wkl index {key} out of range (rows={n})")
+            return _wkl_from_arrow_slice(table.slice(idx, 1))
+
+        # key is a slice at this point (the int path above returned).
+        assert isinstance(key, slice)
+        start, stop, step = key.indices(table.num_rows)
+        if step != 1:
+            raise TypeError(
+                f"Wkl does not support sliced steps (got step={step}). "
+                "Call .resolve() for arbitrary DataFrame slicing."
+            )
+        length = max(0, stop - start)
+        return _wkl_from_arrow_slice(table.slice(start, length))
+
+    def __contains__(self, item: object) -> bool:
+        """True iff ``item`` (as a string) equals any row's ``id`` column.
+
+        Narrow on purpose: the admin-boundary use case is
+        ``uuid in search_result``. Column-scanning for arbitrary values
+        is out of scope — use ``.to_dicts()`` or ``.resolve()`` for that.
+        Returns ``False`` on any failure (root ``Wkl``, missing ``id``
+        column) because ``in`` is a soft-check idiom and shouldn't raise.
+        """
+        if not isinstance(item, str):
+            return False
+        try:
+            table = self._materialize()
+        except ValueError:
+            return False
+        if "id" not in table.column_names:
+            return False
+        id_col = table.column("id")
+        for i in range(id_col.length()):
+            if id_col[i].as_py() == item:
+                return True
+        return False
 
     def __repr__(self) -> str:
         """Return string representation of the underlying data.
@@ -1926,3 +2055,43 @@ class Wkl:
                 query=escaped_query,
             )
         return Wkl(_df=sedona.sql(sql))
+
+
+# --- Surface 2 helpers (module scope so they reference the completed Wkl class)
+
+
+def _wkl_from_arrow_slice(table: pa.Table) -> Wkl:
+    """Wrap a pyarrow Table slice as a result-mode ``Wkl``.
+
+    The slice is re-materialized as a sedona DataFrame via
+    ``sedona.create_data_frame`` so the returned ``Wkl`` has a proper
+    ``_df`` for downstream ``.wkt()`` / ``.path`` / ``.parent`` calls.
+    """
+    return Wkl(_df=sedona.create_data_frame(table))
+
+
+def _wrapped_subset_method(wkl: Wkl, name: str) -> Callable[..., Wkl]:
+    """Return a wrapper around ``df.head`` / ``df.limit`` that returns a ``Wkl``.
+
+    Fixes the ``.head(n).to_dicts()`` usability trap: ``.to_dicts()`` is a
+    ``Wkl`` method, so the inner subset call must return a ``Wkl`` for
+    the chain to type-check end-to-end.
+    """
+    sedona_method = getattr(wkl._df, name)
+
+    def _call(*args: Any, **kwargs: Any) -> Wkl:
+        sub_df = sedona_method(*args, **kwargs)
+        return Wkl(_df=sub_df)
+
+    _call.__name__ = name
+    _call.__qualname__ = f"Wkl.{name}"
+    return _call
+
+
+def _passthrough_error(attr: str) -> str:
+    """Format the AttributeError message for the narrowed __getattr__ passthrough."""
+    return (
+        f"'Wkl' object has no attribute {attr!r}. "
+        f"For DataFrame operations beyond admin-boundary lookup, call "
+        f".resolve() to escape to SedonaDB: wkl.resolve().{attr}(...)"
+    )

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -364,6 +364,10 @@ _S2_REDIRECTS: dict[str, str] = {
     "show": "Use 'wkl[:n]'.",
     "collect": "Use 'list(wkl)'.",
     "to_pylist": "Use 'list(wkl)'.",
+    "tail": "Use 'wkl[-n:]'.",
+    "first": "Use 'wkl[0]'.",
+    "last": "Use 'wkl[-1]'.",
+    "sample": "Use 'wkl.to_arrow_table()' and your engine of choice.",
 }
 
 _S3_REDIRECTS: dict[str, str] = {
@@ -378,6 +382,12 @@ _S3_REDIRECTS: dict[str, str] = {
     "to_geopandas": "Use 'gpd.GeoDataFrame.from_arrow(wkl.to_arrow_table())'.",
     "to_polars": "Use 'pl.from_arrow(wkl.to_arrow_table())'.",
     "to_arrow": "Use 'wkl.to_arrow_table()' (the public name follows SedonaDB/DuckDB convention).",
+    "drop": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "iloc": "Use 'wkl[i]' for positional access.",
+    "loc": "Use 'wkl[i]' for positional access.",
+    "compute": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "distinct": "Use 'wkl.to_arrow_table()' and your engine of choice.",
+    "unique": "Use 'wkl.to_arrow_table()' and your engine of choice.",
 }
 
 _GENERIC_FALLBACK = "Use 'wkl.to_arrow_table()' and your engine of choice."
@@ -1019,14 +1029,14 @@ class Wkl:
     def __getattr__(self, attr: str) -> Wkl:
         """Handle attribute access — chain drill or redirect.
 
-        Two behaviors:
+        Resolution order:
 
-        - **Chain drill** (valid location identifier): drill one level
-          deeper into the admin hierarchy
-          (``wkls.us.ca.sanfrancisco``).
-        - **Redirect**: any attribute that isn't a valid location
-          identifier raises ``AttributeError`` with a priority-ordered
-          suggestion (Surface 1 → Surface 2 → Surface 3).
+        1. Private/dunder attributes → ``AttributeError``.
+        2. Root-only methods → ``AttributeError``.
+        3. Redirect tables (S1 → S2 → S3) → ``AttributeError`` with
+           suggestion.
+        4. Chain drill (alphanumeric location identifier) → new ``Wkl``.
+        5. Generic fallback → ``AttributeError``.
 
         Raises:
             AttributeError: For private/dunder attributes, root-only
@@ -1047,6 +1057,14 @@ class Wkl:
             raise AttributeError(
                 f"'{self.__class__.__name__}' object has no attribute '{attr}'"
             )
+
+        # Redirect check — must fire before chain drill so that known
+        # non-location attrs (e.g. .filter) don't silently extend the chain.
+        for table in (_S1_REDIRECTS, _S2_REDIRECTS, _S3_REDIRECTS):
+            if attr in table:
+                raise AttributeError(
+                    f"'{attr}' is not part of the Wkl API. {table[attr]}"
+                )
 
         # Chain drill: only attempt for names that could be location
         # identifiers (alphanumeric). Result-mode Wkls (no chain, have
@@ -1073,13 +1091,6 @@ class Wkl:
                     parent_id = parent_row.column("id")[0].as_py()
                     return Wkl(new_chain, _parent_id=parent_id)
                 return Wkl(new_chain)
-
-        # Not a location name → redirect with priority.
-        for table in (_S1_REDIRECTS, _S2_REDIRECTS, _S3_REDIRECTS):
-            if attr in table:
-                raise AttributeError(
-                    f"'{attr}' is not part of the Wkl API. {table[attr]}"
-                )
 
         raise AttributeError(
             f"'{attr}' is not part of the Wkl API. {_GENERIC_FALLBACK}"

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1623,18 +1623,6 @@ class Wkl:
         """
         return self._get_geom_expr("ST_AsWKB(geometry)")
 
-    def hexwkb(self) -> str:
-        """Get hex-encoded WKB geometry for the first result.
-
-        Returns:
-            Hex-encoded WKB string.
-
-        Raises:
-            NotImplementedError: This format is not yet supported in SedonaDB.
-        """
-        # return self._get_geom_expr("ST_AsHEXWKB(geometry)")
-        raise NotImplementedError("ST_AsHEXWKB() isn't implemented yet")
-
     def geojson(self) -> str:
         """Get GeoJSON geometry for the first result.
 
@@ -1660,24 +1648,6 @@ class Wkl:
             ... ]
         """
         return self.resolve().to_arrow_table().to_pylist()
-
-    def svg(self, relative: bool = False, precision: int = 15) -> str:
-        """Get SVG path geometry for the first result.
-
-        Args:
-            relative: Use relative coordinates if True.
-            precision: Decimal precision for coordinates.
-
-        Returns:
-            SVG path string.
-
-        Raises:
-            NotImplementedError: This format is not yet supported in SedonaDB.
-        """
-        # return self._get_geom_expr(
-        #     f"ST_AsSVG(geometry, {str(relative).lower()}, {precision})"
-        # )
-        raise NotImplementedError("ST_AsSVG() isn't implemented yet")
 
     def __arrow_c_array__(self, requested_schema=None):
         """Implement the Arrow PyCapsule protocol

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1431,6 +1431,8 @@ class Wkl:
             return self._df
 
         query, params = self._build_query()
+        params["table"] = "wkls"
+        params["columns"] = "*"
         self._df = sedona.sql(
             query.format(**{k: sqlescape(v) for k, v in params.items()})
         )
@@ -1642,19 +1644,133 @@ class Wkl:
         return self._get_geom_expr("ST_AsGeoJSON(geometry)")
 
     def to_dicts(self) -> list[dict[str, Any]]:
-        """Return the rows as a list of plain Python dicts.
+        """Return rows as plain dicts — metadata only, never geometry.
 
-        Convenience for quick iteration and filtering — avoids the
-        pyarrow.Table API. Equivalent to
-        ``self.to_arrow_table().to_pylist()``.
+        The cheap, programmatic-inspection complement to ``to_arrow_table()``.
+        No query against the geometry view, no Arrow extension types — just
+        admin-metadata columns as Python primitives.
 
-        Example:
-            >>> non_us = [
-            ...     r for r in wkls.search("franklin").to_dicts()
-            ...     if r["country"] != "US"
-            ... ]
+        For geometry, use ``to_arrow_table()`` (multi-row, GeoArrow WKB)
+        or the single-row terminals (``.wkt()`` / ``.geojson()`` / ``.wkb()``).
+
+        Examples:
+            >>> hits = wkls.search("franklin").to_dicts()
+            >>> [r for r in hits if r["country"] != "US"]
         """
         return self._resolve().to_arrow_table().to_pylist()
+
+    def to_arrow_table(self) -> pa.Table:
+        """Materialize this Wkl as a pyarrow.Table — the Surface 3 escape.
+
+        Returns a standalone pyarrow.Table suitable for handoff to any
+        Arrow-aware engine (sedona, DuckDB, GeoPandas, Polars).
+        Geometry is included as a GeoArrow WKB extension column with
+        CRS = OGC:CRS84.
+
+        Chain-mode Wkls (e.g. ``wkls.us.ca.cities()``) issue a single
+        query directly against the Overture parquet — no local-then-remote
+        two-pass. Result-mode Wkls (from ``.search()``, ``.by_id()``)
+        use an id-based lookup against Overture.
+
+        For metadata-only inspection (no geometry), use ``to_dicts()``
+        instead.
+
+        Returns:
+            pyarrow.Table with metadata columns plus a 'geometry' column
+            typed as ``geoarrow.wkb<OGC:CRS84>``.
+
+        Raises:
+            ValueError: If the chain is empty and no cached DataFrame is
+                available (root Wkl).
+
+        Examples:
+            >>> tbl = wkls.us.ca.cities().to_arrow_table()
+            >>> import geopandas as gpd
+            >>> gdf = gpd.GeoDataFrame.from_arrow(tbl)
+
+            >>> # DuckDB
+            >>> import duckdb
+            >>> duckdb.from_arrow(tbl)
+        """
+        import geoarrow.pyarrow as ga  # noqa: F811
+
+        _ensure_overture_loaded()
+
+        if self._df is not None:
+            return self._to_arrow_table_from_df()
+
+        if not self.chain:
+            raise ValueError(
+                "No attributes in the chain. Use wkls.<country> or "
+                "wkls.<country>.<region>, etc."
+            )
+
+        # Build the same query _resolve() would, but against overture
+        # with geometry projection.
+        query, params = self._build_query()
+        params["table"] = "overture"
+        params["columns"] = queries.GEOMETRY_COLUMNS
+
+        df = sedona.sql(query.format(**{k: sqlescape(v) for k, v in params.items()}))
+        tbl = df.to_arrow_table()
+
+        return self._apply_geoarrow_encoding(tbl)
+
+    def _to_arrow_table_from_df(self) -> pa.Table:
+        """IN-list fallback for result-mode Wkls."""
+        import geoarrow.pyarrow as ga  # noqa: F811
+
+        _ensure_overture_loaded()
+
+        meta_tbl = self._df.to_arrow_table()
+        ids = meta_tbl.column("id").to_pylist()
+
+        if ids:
+            id_list = ", ".join(f"'{sqlescape(i)}'" for i in ids)
+            geom_df = sedona.sql(
+                "SELECT id, ST_AsBinary(geometry) AS geometry "
+                f"FROM overture WHERE id IN ({id_list})"
+            )
+            geom_tbl = geom_df.to_arrow_table()
+        else:
+            geom_tbl = pa.table(
+                {
+                    "id": pa.array([], type=meta_tbl.schema.field("id").type),
+                    "geometry": pa.array([], type=pa.binary()),
+                }
+            )
+
+        # Hash-join in Python (small N, trivial).
+        id_to_wkb: dict = dict(
+            zip(
+                geom_tbl.column("id").to_pylist(),
+                geom_tbl.column("geometry").to_pylist(),
+            )
+        )
+        wkb_col = pa.array([id_to_wkb.get(i) for i in ids], type=pa.binary())
+        return self._apply_geoarrow_encoding(
+            meta_tbl.append_column("geometry", ga.with_crs(wkb_col, crs=ga.OGC_CRS84))
+        )
+
+    @staticmethod
+    def _apply_geoarrow_encoding(tbl: pa.Table) -> pa.Table:
+        """Cast the geometry column to GeoArrow WKB extension type.
+
+        Handles the binary_view → binary cast that SedonaDB's
+        ST_AsBinary emits, and wraps with OGC:CRS84 CRS metadata.
+        """
+        import geoarrow.pyarrow as ga  # noqa: F811
+
+        geom_idx = tbl.schema.get_field_index("geometry")
+        wkb_col = tbl.column(geom_idx)
+
+        # ST_AsBinary surfaces as binary_view in pyarrow; ga.with_crs
+        # rejects binary_view, so cast to plain binary first.
+        if wkb_col.type == pa.binary_view():
+            wkb_col = wkb_col.cast(pa.binary())
+
+        geo_col = ga.with_crs(wkb_col, crs=ga.OGC_CRS84)
+        return tbl.set_column(geom_idx, "geometry", geo_col)
 
     def __arrow_c_array__(self, requested_schema=None):
         """Implement the Arrow PyCapsule protocol
@@ -2045,6 +2161,7 @@ def _wkl_from_arrow_slice(table: pa.Table) -> Wkl:
     ``_df`` for downstream ``.wkt()`` / ``.path`` / ``.parent`` calls.
     """
     return Wkl(_df=sedona.create_data_frame(table))
+
 
 
 def _wrapped_subset_method(wkl: Wkl, name: str) -> Callable[..., Wkl]:

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -12,8 +12,14 @@ INITIALIZATION = """
 
 # --- Resolution queries (for resolving location chains) ---
 
+# Column sets for the two query modes.
+# _resolve() queries the local `wkls` table (metadata only).
+# to_arrow_table() queries `overture` (metadata + geometry).
+METADATA_COLUMNS = "id, country, region, subtype, name_primary, name_en, parent_id"
+GEOMETRY_COLUMNS = f"{METADATA_COLUMNS}, ST_AsBinary(geometry) AS geometry"
+
 COUNTRY_DEPENDENCY = """
-    SELECT * FROM wkls
+    SELECT {columns} FROM {table}
     WHERE subtype IN ('country', 'dependency')
       AND (
         country ILIKE '{country}'
@@ -23,7 +29,7 @@ COUNTRY_DEPENDENCY = """
 """
 
 REGION = """
-    SELECT * FROM wkls
+    SELECT {columns} FROM {table}
     WHERE country ILIKE '{country}'
       AND subtype = 'region'
       AND (
@@ -76,7 +82,7 @@ ROW_BY_ID = """
 # Matches by parent_id AND location name. parent_id self-references
 # another row's ``id`` within the bundled metadata.
 CHILDREN_BY_PARENT = """
-    SELECT * FROM wkls
+    SELECT {columns} FROM {table}
     WHERE parent_id = '{parent_id}'
       AND (
         REPLACE(name_primary, ' ', '') ILIKE REPLACE('{name}', ' ', '')
@@ -85,7 +91,7 @@ CHILDREN_BY_PARENT = """
 """
 
 CITY = """
-    SELECT * FROM wkls
+    SELECT {columns} FROM {table}
     WHERE country ILIKE '{country}'
       AND region ILIKE '{region}'
       AND subtype IN ('county', 'locality', 'localadmin')
@@ -97,7 +103,7 @@ CITY = """
 """
 
 CITY_NO_REGION = """
-    SELECT * FROM wkls
+    SELECT {columns} FROM {table}
     WHERE country ILIKE '{country}'
       AND subtype IN ('county', 'locality', 'localadmin')
       AND (


### PR DESCRIPTION
## Summary

Ship the three-surface API for wkls v1.2.0:

- **Surface 1** (dot-chain navigation) — unchanged, remains primary identity
- **Surface 2** (Python collection protocol) — `len()`, `iter()`, `[]`, `in`, `bool()`
- **Surface 3** (Arrow escape) — `to_arrow_table()` returns `pyarrow.Table` with GeoArrow WKB geometry

### Breaking changes

- `resolve()` removed — use `to_arrow_table()` instead
- `svg()` and `hexwkb()` removed (were `NotImplementedError` stubs)
- `__getattr__` passthrough removed — `.count()`, `.head()`, `.show()`, `.filter()` etc. now raise `AttributeError` with priority-ordered redirects pointing at the correct Surface
- `to_dicts()` is metadata-only by contract (no geometry)

### Commits

1. `feat!: remove unimplemented svg() and hexwkb() methods`
2. `refactor: rename Wkl.resolve to private _resolve`
3. `feat!: add Wkl.to_arrow_table() with direct Overture query`
4. `feat!: empty __getattr__ allowlist with priority-ordered redirects`
5. `docs: README + CHANGELOG for v1.2.0`