### PR TITLE
fix: ambiguity template polish and geometry docstrings

### DIFF
--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -63,7 +63,7 @@ def test_ambiguity_error_indistinguishable_candidates_uses_by_id():
     else:
         pytest.fail("expected AmbiguousLocationError")
     assert "Narrow with one of" in msg
-    assert "Or pick by id" in msg
+    assert "Pick by id" in msg
     # Two literal by_id calls, one per candidate.
     assert msg.count("wkls.by_id('") == 2
 
@@ -93,7 +93,7 @@ def test_ambiguity_error_suggests_subtype_narrowing_when_subtypes_differ():
         msg = str(e)
     else:
         pytest.fail("expected AmbiguousLocationError")
-    assert "filter by subtype on this result" in msg
+    assert "Filter by subtype on this result" in msg
     assert ".cities()" in msg
     assert ".counties()" in msg
     # by_id still advertised as the universal escape hatch.

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -1668,6 +1668,7 @@ class Wkl:
 
         Raises:
             ValueError: If no results found for the location chain.
+            AmbiguousLocationError: If the chain matches multiple rows.
         """
         return self._get_geom_expr("ST_AsText(geometry)")
 
@@ -1679,6 +1680,7 @@ class Wkl:
 
         Raises:
             ValueError: If no results found for the location chain.
+            AmbiguousLocationError: If the chain matches multiple rows.
         """
         return self._get_geom_expr("ST_AsWKB(geometry)")
 
@@ -1690,6 +1692,7 @@ class Wkl:
 
         Raises:
             ValueError: If no results found for the location chain.
+            AmbiguousLocationError: If the chain matches multiple rows.
         """
         return self._get_geom_expr("ST_AsGeoJSON(geometry)")
 

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -748,7 +748,7 @@ class Wkl:
                 by_method.setdefault(method, []).append(c["subtype"])
         if len(by_method) > 1:
             lines.append("")
-            lines.append("Or filter by subtype on this result:")
+            lines.append("Filter by subtype on this result:")
             for method, subtypes in by_method.items():
                 label = "/".join(sorted(set(subtypes)))
                 lines.append(f"  .{method}()  # {len(subtypes)} {label} row(s)")
@@ -756,7 +756,7 @@ class Wkl:
         # Always show by_id lines with literal UUID + .wkt() call so agents
         # can copy-paste directly.
         lines.append("")
-        lines.append("Or pick by id:")
+        lines.append("Pick by id:")
         id_cap = 5
         for c in candidates[:id_cap]:
             parent_note = f", in {c['parent_name']}" if c["parent_name"] else ""


### PR DESCRIPTION
## Summary
- Drop stranded "Or" prefix from ambiguity error sub-options after "Narrow with one of:" header
- Document `AmbiguousLocationError` in `wkt`/`wkb`/`geojson` Raises sections