### PR TITLE
refactor: code quality cleanup (parameterized queries, dedup, dead code)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "sedonadb>=0.3.0",
     "pyarrow>=14.0.0",
     "geoarrow-pyarrow>=0.2.0",
-    "sqlescapy>=1.0.1",
 ]
 authors = [
     { name = "Pranav Toggi", email = "pranav@wherobots.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -350,15 +350,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sqlescapy"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/bb/d5077ee1599474af84393bc000212d2aa29e846e10044c4a5eb0813f2339/sqlescapy-1.0.1.tar.gz", hash = "sha256:281c27266e9f6934a7728a7272b2299bce395d0aeb12a314641add1ffd7e0872", size = 1520 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/6a/bd5df7aeed348a0ac9d2d0417128ed82af6291bd76afb16254379a55ad3f/sqlescapy-1.0.1-py3-none-any.whl", hash = "sha256:3a50b4b1eb8971b51a3c097c37cd58921a8f9e296619534aed515116356f5fbf", size = 2792 },
-]
-
-[[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -415,7 +406,6 @@ dependencies = [
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "23.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sedonadb" },
-    { name = "sqlescapy" },
 ]
 
 [package.dev-dependencies]
@@ -429,7 +419,6 @@ requires-dist = [
     { name = "geoarrow-pyarrow", specifier = ">=0.2.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "sedonadb", specifier = ">=0.3.0" },
-    { name = "sqlescapy", specifier = ">=1.0.1" },
 ]
 
 [package.metadata.requires-dev]

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -29,7 +29,6 @@ from typing import Any, Callable
 
 import pyarrow as pa
 import sedonadb
-import sqlescapy
 
 from . import data, queries
 
@@ -151,20 +150,25 @@ def _overture_uri(version: str) -> str:
 
 
 def _log_and_query(
-    exec_fn: Callable[[str], sedonadb.dataframe.DataFrame], query: str
+    exec_fn: Callable[..., sedonadb.dataframe.DataFrame],
+    query: str,
+    **kwargs: Any,
 ) -> sedonadb.dataframe.DataFrame:
     """Execute a SQL query with optional debug logging.
 
     Args:
         exec_fn: Function to execute the SQL query.
         query: SQL query string to execute.
+        **kwargs: Additional keyword arguments passed to exec_fn (e.g. params).
 
     Returns:
         DataFrame containing the query results.
     """
     if os.environ.get("WKLS_DEBUG", "false").lower() in ["true", "yes", "1"]:
         print(query)
-    return exec_fn(query)
+        if kwargs:
+            print(f"  params={kwargs}")
+    return exec_fn(query, **kwargs)
 
 
 def _initialize_table() -> sedonadb.SedonaContext:
@@ -185,7 +189,7 @@ def _initialize_table() -> sedonadb.SedonaContext:
 
     # Monkey-patch `.sql()` for debug mode.
     sedona_sql = sedona.sql
-    sedona.sql = lambda q: _log_and_query(sedona_sql, q)
+    sedona.sql = lambda q, **kw: _log_and_query(sedona_sql, q, **kw)
 
     sedona.sql(queries.INITIALIZATION)
     sedona.read_parquet(
@@ -277,21 +281,6 @@ _row_info: dict[str, dict[str, object]] = {}
 
 
 _seed_country_info()
-
-
-def sqlescape(v: str) -> str:
-    """Escape a string for safe SQL interpolation.
-
-    Escapes special characters while preserving % for LIKE operators.
-
-    Args:
-        v: String value to escape.
-
-    Returns:
-        SQL-safe escaped string.
-    """
-    # SQL escape, but maintain the use of % for the LIKE operator.
-    return sqlescapy.sqlescape(v).replace("\\%", "%")
 
 
 # Methods surfaced by __dir__ at each chain depth.
@@ -611,12 +600,12 @@ class Wkl:
             Tuple of (canonical ISO, has_region). For unknown inputs,
             the uppercased original string and ``False``.
         """
-        df = sedona.sql(queries.COUNTRY_LOOKUP.format(identifier=sqlescape(identifier)))
+        df = sedona.sql(queries.COUNTRY_LOOKUP, params={"identifier": identifier})
         table = df.to_arrow_table()
         if table.num_rows == 0:
             return identifier.upper(), False
         iso = table.column("iso")[0].as_py()
-        df_has = sedona.sql(queries.COUNTRY_HAS_REGIONS.format(country=sqlescape(iso)))
+        df_has = sedona.sql(queries.COUNTRY_HAS_REGIONS, params={"country": iso})
         return iso, df_has.count() > 0
 
     @property
@@ -645,11 +634,12 @@ class Wkl:
             else f"{self._country_iso}-{identifier.upper()}"
         )
         df = sedona.sql(
-            queries.REGION_LOOKUP.format(
-                country=sqlescape(self._country_iso),
-                identifier=sqlescape(full_iso),
-                name=sqlescape(identifier),
-            )
+            queries.REGION_LOOKUP,
+            params={
+                "country": self._country_iso,
+                "identifier": full_iso,
+                "name": identifier,
+            },
         )
         table = df.to_arrow_table()
         if table.num_rows == 0:
@@ -801,7 +791,7 @@ class Wkl:
             >>> wkls.by_id('273bc9a0-96a1-402c-992c-84f5c2f212cb').wkt()
             'POLYGON (((...)))'
         """
-        df = sedona.sql(queries.ROW_BY_ID.format(row_id=sqlescape(row_id)))
+        df = sedona.sql(queries.ROW_BY_ID, params={"row_id": row_id})
         if df.count() == 0:
             raise ValueError(f"No row found with id={row_id!r}.")
         return cls(_df=df)
@@ -919,7 +909,7 @@ class Wkl:
         """
         if row_id in _row_info:
             return _row_info[row_id]
-        df = sedona.sql(queries.ROW_BY_ID.format(row_id=sqlescape(row_id)))
+        df = sedona.sql(queries.ROW_BY_ID, params={"row_id": row_id})
         table = df.to_arrow_table()
         if table.num_rows == 0:
             return None
@@ -1159,9 +1149,7 @@ class Wkl:
         """Return cached region-level dir entries (ISO suffixes + names)."""
         key: tuple[str, ...] = (self._country_iso,)
         if key not in _dir_cache:
-            df = sedona.sql(
-                queries.DIR_REGIONS.format(country=sqlescape(self._country_iso))
-            )
+            df = sedona.sql(queries.DIR_REGIONS, params={"country": self._country_iso})
             _dir_cache[key] = self._collect_dir_entries(df)
         return _dir_cache[key]
 
@@ -1480,11 +1468,8 @@ class Wkl:
             return self._df
 
         query, params = self._build_query()
-        params["table"] = "wkls"
-        params["columns"] = "*"
-        self._df = sedona.sql(
-            query.format(**{k: sqlescape(v) for k, v in params.items()})
-        )
+        sql = query.format(table="wkls", columns="*")
+        self._df = sedona.sql(sql, params=params)
         return self._df
 
     def _get_suggestions(
@@ -1515,40 +1500,37 @@ class Wkl:
 
         if len(self.chain) == 1:
             # Country-level suggestions (prefix match on ISO codes)
-            query = queries.SUGGEST_COUNTRY.format(
-                search_term=sqlescape(search_term),
-                limit=n,
-            )
+            query = queries.SUGGEST_COUNTRY.format(limit=n)
+            params = {"search_term": search_term}
         elif len(self.chain) == 2:
             country_iso = self._country_iso
             if self._has_region:
                 # Region-level suggestions (prefix match on region codes)
-                query = queries.SUGGEST_REGION.format(
-                    country=sqlescape(country_iso),
-                    search_term=sqlescape(search_term),
-                    limit=n,
-                )
+                query = queries.SUGGEST_REGION.format(limit=n)
+                params = {"country": country_iso, "search_term": search_term}
             else:
                 # City-level for countries without regions (e.g., wkls.fk.stoney)
                 query = queries.SUGGEST_CITY.format(
-                    country=sqlescape(country_iso),
                     region_filter="",
-                    search_term=sqlescape(search_term),
                     limit=n * 2,
                 )
+                params = {"country": country_iso, "search_term": search_term}
                 use_distance_filter = True
         else:
             # City-level with region (e.g., wkls.us.ca.sanfran)
             country_iso = self._country_iso
             query = queries.SUGGEST_CITY.format(
-                country=sqlescape(country_iso),
-                region_filter=f"AND region = '{sqlescape(self._region_iso)}'",
-                search_term=sqlescape(search_term),
+                region_filter="AND region = $region",
                 limit=n * 2,
             )
+            params = {
+                "country": country_iso,
+                "region": self._region_iso,
+                "search_term": search_term,
+            }
             use_distance_filter = True
 
-        result = sedona.sql(query)
+        result = sedona.sql(query, params=params)
 
         table = result.to_arrow_table()
         if table.num_rows == 0:
@@ -1623,24 +1605,27 @@ class Wkl:
         name_primary = row.column("name_primary")[0].as_py()
 
         base_conditions = [
-            f"country = '{sqlescape(country)}'",
-            f"subtype = '{sqlescape(subtype)}'",
+            "country = $country",
+            "subtype = $subtype",
             "is_land = true",
         ]
+        base_params: dict[str, str] = {"country": country, "subtype": subtype}
         if region:
-            base_conditions.append(f"region = '{sqlescape(region)}'")
+            base_conditions.append("region = $region")
+            base_params["region"] = region
 
-        def _fetch(extra: str) -> Any | None:
-            clauses = " AND ".join(base_conditions + [extra])
+        def _fetch(extra_clause: str, extra_params: dict[str, str]) -> Any | None:
+            clauses = " AND ".join(base_conditions + [extra_clause])
             tbl = sedona.sql(
-                f"SELECT {expr} FROM overture WHERE {clauses} LIMIT 1"
+                f"SELECT {expr} FROM overture WHERE {clauses} LIMIT 1",
+                params={**base_params, **extra_params},
             ).to_arrow_table()
             if tbl.num_rows == 0:
                 return None
             return tbl.column(0)[0].as_py()
 
         # Path 1: id match (the common case).
-        result = _fetch(f"id = '{sqlescape(gers_id)}'")
+        result = _fetch("id = $id", {"id": gers_id})
         if result is not None:
             return result
 
@@ -1648,7 +1633,9 @@ class Wkl:
         # as a secondary key. Country/region/dependency are unique by
         # country+region+subtype, so no fallback possible or needed there.
         if subtype in ("county", "locality", "localadmin"):
-            result = _fetch(f"names.primary = '{sqlescape(name_primary)}'")
+            result = _fetch(
+                "names.primary = $name_primary", {"name_primary": name_primary}
+            )
             if result is not None:
                 return result
 
@@ -1758,10 +1745,9 @@ class Wkl:
         # Build the same query _resolve() would, but against overture
         # with geometry projection.
         query, params = self._build_query()
-        params["table"] = "overture"
-        params["columns"] = queries.GEOMETRY_COLUMNS
+        sql = query.format(table="overture", columns=queries.GEOMETRY_COLUMNS)
 
-        df = sedona.sql(query.format(**{k: sqlescape(v) for k, v in params.items()}))
+        df = sedona.sql(sql, params=params)
         tbl = df.to_arrow_table()
 
         return self._apply_geoarrow_encoding(tbl)
@@ -1776,10 +1762,12 @@ class Wkl:
         ids = meta_tbl.column("id").to_pylist()
 
         if ids:
-            id_list = ", ".join(f"'{sqlescape(i)}'" for i in ids)
+            placeholders = ", ".join(f"$id_{i}" for i in range(len(ids)))
+            id_params = {f"id_{i}": v for i, v in enumerate(ids)}
             geom_df = sedona.sql(
                 "SELECT id, ST_AsBinary(geometry) AS geometry "
-                f"FROM overture WHERE id IN ({id_list})"
+                f"FROM overture WHERE id IN ({placeholders})",
+                params=id_params,
             )
             geom_tbl = geom_df.to_arrow_table()
         else:
@@ -1895,20 +1883,24 @@ class Wkl:
             return self._narrow_result_mode_by_subtypes(f"('{subtype}')")
 
         if not self.chain:
-            query = f"""
+            query = """
                 SELECT DISTINCT id, country, subtype, name_primary, name_en
                 FROM wkls
-                WHERE subtype = '{subtype}'
+                WHERE subtype = $subtype
             """
-            return Wkl(_df=sedona.sql(query))
+            return Wkl(_df=sedona.sql(query, params={"subtype": subtype}))
 
-        query = f"""
+        query = """
             SELECT DISTINCT id, country, subtype, name_primary, name_en
             FROM wkls
-            WHERE subtype = '{subtype}'
-              AND country = '{{country}}'
+            WHERE subtype = $subtype
+              AND country = $country
         """
-        return Wkl(_df=sedona.sql(query.format(country=sqlescape(self._country_iso))))
+        return Wkl(
+            _df=sedona.sql(
+                query, params={"subtype": subtype, "country": self._country_iso}
+            )
+        )
 
     def regions(self) -> Wkl:
         """List regions in the current chain scope.
@@ -1987,27 +1979,26 @@ class Wkl:
             # (which addresses a specific city, so scope collapses to country).
             query = f"""
                 SELECT * FROM wkls
-                WHERE country = '{{country}}'
+                WHERE country = $country
                   AND subtype IN {subtype_filter}
             """
-            return Wkl(
-                _df=sedona.sql(query.format(country=sqlescape(self._country_iso)))
-            )
+            return Wkl(_df=sedona.sql(query, params={"country": self._country_iso}))
 
         if depth == 2:
             # Region-scoped.
             query = f"""
                 SELECT * FROM wkls
-                WHERE country = '{{country}}'
-                  AND region = '{{region}}'
+                WHERE country = $country
+                  AND region = $region
                   AND subtype IN {subtype_filter}
             """
             return Wkl(
                 _df=sedona.sql(
-                    query.format(
-                        country=sqlescape(self._country_iso),
-                        region=sqlescape(self._region_iso),
-                    )
+                    query,
+                    params={
+                        "country": self._country_iso,
+                        "region": self._region_iso,
+                    },
                 )
             )
 
@@ -2028,10 +2019,10 @@ class Wkl:
         row_id = df.head(1).to_arrow_table().column("id")[0].as_py()
         query = f"""
             SELECT * FROM wkls
-            WHERE (id = '{{row_id}}' OR parent_id = '{{row_id}}')
+            WHERE (id = $row_id OR parent_id = $row_id)
               AND subtype IN {subtype_filter}
         """
-        return Wkl(_df=sedona.sql(query.format(row_id=sqlescape(row_id))))
+        return Wkl(_df=sedona.sql(query, params={"row_id": row_id}))
 
     def counties(self) -> Wkl:
         """List counties in the current chain scope.
@@ -2095,23 +2086,22 @@ class Wkl:
         if depth == 1 or not self._has_region:
             query = """
                 SELECT DISTINCT subtype FROM wkls
-                WHERE country = '{country}'
+                WHERE country = $country
             """
-            return Wkl(
-                _df=sedona.sql(query.format(country=sqlescape(self._country_iso)))
-            )
+            return Wkl(_df=sedona.sql(query, params={"country": self._country_iso}))
 
         if depth == 2:
             query = """
                 SELECT DISTINCT subtype FROM wkls
-                WHERE country = '{country}' AND region = '{region}'
+                WHERE country = $country AND region = $region
             """
             return Wkl(
                 _df=sedona.sql(
-                    query.format(
-                        country=sqlescape(self._country_iso),
-                        region=sqlescape(self._region_iso),
-                    )
+                    query,
+                    params={
+                        "country": self._country_iso,
+                        "region": self._region_iso,
+                    },
                 )
             )
 
@@ -2127,9 +2117,9 @@ class Wkl:
         row_id = df.head(1).to_arrow_table().column("id")[0].as_py()
         query = """
             SELECT DISTINCT subtype FROM wkls
-            WHERE id = '{row_id}' OR parent_id = '{row_id}'
+            WHERE id = $row_id OR parent_id = $row_id
         """
-        return Wkl(_df=sedona.sql(query.format(row_id=sqlescape(row_id))))
+        return Wkl(_df=sedona.sql(query, params={"row_id": row_id}))
 
     def search(self, query: str) -> Wkl:
         """Search for locations whose names contain a substring.
@@ -2179,7 +2169,7 @@ class Wkl:
 
         # Normalize to the dot-access form so ``search("sanfrancisco")``
         # and ``search("San Francisco")`` both match "San Francisco".
-        escaped_query = sqlescape(_normalize_name(query))
+        normalized_query = _normalize_name(query)
 
         # Result-mode: narrow within the already-resolved rows. The
         # previous search/listing call has already scoped the data; a
@@ -2187,25 +2177,35 @@ class Wkl:
         if depth == 0 and self._df is not None:
             view_name = "_wkls_search_within"
             self._df.to_view(view_name, overwrite=True)
-            sql = queries.SEARCH_WITHIN_VIEW.format(
-                view_name=view_name, query=escaped_query
-            )
-            return Wkl(_df=sedona.sql(sql))
+            sql = queries.SEARCH_WITHIN_VIEW.format(view_name=view_name)
+            return Wkl(_df=sedona.sql(sql, params={"query": normalized_query}))
 
         if depth == 0:
-            sql = queries.SEARCH_ROOT.format(query=escaped_query)
+            return Wkl(
+                _df=sedona.sql(queries.SEARCH_ROOT, params={"query": normalized_query})
+            )
         elif depth == 1 or not self._has_region:
             # Depth 1, or depth 2 on a country that doesn't use regions.
-            sql = queries.SEARCH_COUNTRY.format(
-                country=sqlescape(self._country_iso), query=escaped_query
+            return Wkl(
+                _df=sedona.sql(
+                    queries.SEARCH_COUNTRY,
+                    params={
+                        "country": self._country_iso,
+                        "query": normalized_query,
+                    },
+                )
             )
         else:  # depth == 2 with regions
-            sql = queries.SEARCH_REGION.format(
-                country=sqlescape(self._country_iso),
-                region=sqlescape(self._region_iso),
-                query=escaped_query,
+            return Wkl(
+                _df=sedona.sql(
+                    queries.SEARCH_REGION,
+                    params={
+                        "country": self._country_iso,
+                        "region": self._region_iso,
+                        "query": normalized_query,
+                    },
+                )
             )
-        return Wkl(_df=sedona.sql(sql))
 
 
 # --- Surface 2 helpers (module scope so they reference the completed Wkl class)

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -221,21 +221,24 @@ def _seed_country_info() -> None:
 sedona = _initialize_table()
 
 
-def _ensure_overture_loaded() -> None:
+def _ensure_overture_loaded(*, force: bool = False) -> None:
     """Register the remote Overture GeoParquet view on first geometry access.
 
     Resolves the active Overture version (via ``WKLS_OVERTURE_VERSION``,
     module-level cache, or an S3 listing), then registers the remote
     GeoParquet as the ``overture`` SedonaDB view. Idempotent — later
-    calls short-circuit on ``_overture_view_loaded``. ``configure()``
-    sets the flag too, so a user-driven reload keeps the fast path.
+    calls short-circuit on ``_overture_view_loaded`` unless *force* is
+    set (used by ``configure()`` to reload after a version change).
+
+    Args:
+        force: If True, reload the view even if already loaded.
 
     Raises:
         ConnectionError: If the S3 listing or parquet read fails. The
             message points at the network requirement.
     """
     global _current_overture_version, _overture_view_loaded
-    if _overture_view_loaded:
+    if _overture_view_loaded and not force:
         return
     if _current_overture_version is None:
         _current_overture_version = _resolve_overture_version()
@@ -994,7 +997,7 @@ class Wkl:
             >>> wkls.overture_version()
             '2025-12-17.0'
         """
-        global _current_overture_version, _overture_view_loaded
+        global _current_overture_version
 
         if self.chain:
             raise ValueError(
@@ -1016,14 +1019,7 @@ class Wkl:
         _dir_cache.clear()
         _row_info.clear()
         _seed_country_info()
-        sedona.read_parquet(
-            _overture_uri(overture_version),
-            options={
-                "aws.skip_signature": True,
-                "aws.region": "us-west-2",
-            },
-        ).to_view("overture", overwrite=True)
-        _overture_view_loaded = True
+        _ensure_overture_loaded(force=True)
 
     def __getattr__(self, attr: str) -> Wkl:
         """Handle attribute access — chain drill or redirect.

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -416,6 +416,17 @@ _STR_SUBSCRIPT_MSG = (
     "  - For arbitrary DataFrame ops: call .to_arrow_table() and use your engine of choice"
 )
 
+# Maps admin subtype → listing method name. Used by
+# _ambiguity_message to suggest subtype-narrowing calls.
+_METHOD_FOR_SUBTYPE: dict[str, str] = {
+    "country": "countries",
+    "dependency": "dependencies",
+    "region": "regions",
+    "county": "counties",
+    "locality": "cities",
+    "localadmin": "cities",
+}
+
 
 def _normalize_name(name: str | None) -> str:
     """Lowercase + strip non-alphanumerics. Matches ``__getattr__`` input form."""
@@ -491,7 +502,7 @@ class Wkl:
 
     Iteration is backed by a cached pyarrow Table — no SQL per row. For
     DataFrame operations outside admin-boundary lookup (``.filter``,
-    ``.join``, ``.group_by``, …), call ``.resolve()``.
+    ``.join``, ``.group_by``, …), call ``.to_arrow_table()``.
     """
 
     _has_region: bool = True
@@ -733,14 +744,6 @@ class Wkl:
         # subtype *groups* (two rows both in ``locality`` don't get a
         # suggestion since ``.cities()`` wouldn't reduce anything). Shown
         # alongside the primary narrower, before ``by_id``.
-        _METHOD_FOR_SUBTYPE = {
-            "country": "countries",
-            "dependency": "dependencies",
-            "region": "regions",
-            "county": "counties",
-            "locality": "cities",
-            "localadmin": "cities",
-        }
         by_method: dict[str, list[str]] = {}
         for c in candidates:
             method = _METHOD_FOR_SUBTYPE.get(c["subtype"])

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -113,43 +113,6 @@ CITY_NO_REGION = """
     )
 """
 
-# --- Metadata queries ---
-
-REGIONS_LIST = """
-    SELECT * FROM wkls
-    WHERE country = $country
-      AND subtype = 'region'
-"""
-
-COUNTRIES_LIST = """
-    SELECT DISTINCT id, country, subtype, name_primary, name_en
-    FROM wkls
-    WHERE subtype = 'country'
-"""
-
-DEPENDENCIES_LIST = """
-    SELECT DISTINCT id, country, subtype, name_primary, name_en
-    FROM wkls
-    WHERE subtype = 'dependency'
-"""
-
-SUBTYPES_LIST = """
-    SELECT DISTINCT subtype FROM wkls
-"""
-
-SUBDIVISIONS = """
-    SELECT * FROM wkls
-    WHERE country = $country
-      AND region = $region
-      AND subtype IN {subtype_filter}
-"""
-
-SUBDIVISIONS_NO_REGION = """
-    SELECT * FROM wkls
-    WHERE country = $country
-      AND subtype IN {subtype_filter}
-"""
-
 # --- Suggestion queries (for "did you mean" feature) ---
 
 # For country-level suggestions (bidirectional prefix match on ISO codes)

--- a/wkls/queries.py
+++ b/wkls/queries.py
@@ -22,20 +22,20 @@ COUNTRY_DEPENDENCY = """
     SELECT {columns} FROM {table}
     WHERE subtype IN ('country', 'dependency')
       AND (
-        country ILIKE '{country}'
-        OR REPLACE(name_en, ' ', '') ILIKE REPLACE('{country}', ' ', '')
-        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE('{country}', ' ', '')
+        country ILIKE $country
+        OR REPLACE(name_en, ' ', '') ILIKE REPLACE($country, ' ', '')
+        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE($country, ' ', '')
       )
 """
 
 REGION = """
     SELECT {columns} FROM {table}
-    WHERE country ILIKE '{country}'
+    WHERE country ILIKE $country
       AND subtype = 'region'
       AND (
-        region ILIKE '{region}'
-        OR REPLACE(name_en, ' ', '') ILIKE REPLACE('{region_name}', ' ', '')
-        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE('{region_name}', ' ', '')
+        region ILIKE $region
+        OR REPLACE(name_en, ' ', '') ILIKE REPLACE($region_name, ' ', '')
+        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE($region_name, ' ', '')
       )
 """
 
@@ -44,16 +44,16 @@ COUNTRY_LOOKUP = """
     FROM wkls
     WHERE subtype IN ('country', 'dependency')
       AND (
-        country ILIKE '{identifier}'
-        OR REPLACE(name_en, ' ', '') ILIKE REPLACE('{identifier}', ' ', '')
-        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE('{identifier}', ' ', '')
+        country ILIKE $identifier
+        OR REPLACE(name_en, ' ', '') ILIKE REPLACE($identifier, ' ', '')
+        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE($identifier, ' ', '')
       )
     LIMIT 1
 """
 
 COUNTRY_HAS_REGIONS = """
     SELECT * FROM wkls
-    WHERE country = '{country}'
+    WHERE country = $country
       AND subtype = 'region'
       LIMIT 1
 """
@@ -61,12 +61,12 @@ COUNTRY_HAS_REGIONS = """
 REGION_LOOKUP = """
     SELECT DISTINCT region AS iso
     FROM wkls
-    WHERE country = '{country}'
+    WHERE country = $country
       AND subtype = 'region'
       AND (
-        region ILIKE '{identifier}'
-        OR REPLACE(name_en, ' ', '') ILIKE REPLACE('{name}', ' ', '')
-        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE('{name}', ' ', '')
+        region ILIKE $identifier
+        OR REPLACE(name_en, ' ', '') ILIKE REPLACE($name, ' ', '')
+        OR REPLACE(name_primary, ' ', '') ILIKE REPLACE($name, ' ', '')
       )
     LIMIT 1
 """
@@ -74,7 +74,7 @@ REGION_LOOKUP = """
 ROW_BY_ID = """
     SELECT id, country, region, subtype, name_primary, name_en, parent_id
     FROM wkls
-    WHERE id = '{row_id}'
+    WHERE id = $row_id
     LIMIT 1
 """
 
@@ -83,33 +83,33 @@ ROW_BY_ID = """
 # another row's ``id`` within the bundled metadata.
 CHILDREN_BY_PARENT = """
     SELECT {columns} FROM {table}
-    WHERE parent_id = '{parent_id}'
+    WHERE parent_id = $parent_id
       AND (
-        REPLACE(name_primary, ' ', '') ILIKE REPLACE('{name}', ' ', '')
-        OR REPLACE(name_en, ' ', '') ILIKE REPLACE('{name}', ' ', '')
+        REPLACE(name_primary, ' ', '') ILIKE REPLACE($name, ' ', '')
+        OR REPLACE(name_en, ' ', '') ILIKE REPLACE($name, ' ', '')
       )
 """
 
 CITY = """
     SELECT {columns} FROM {table}
-    WHERE country ILIKE '{country}'
-      AND region ILIKE '{region}'
+    WHERE country ILIKE $country
+      AND region ILIKE $region
       AND subtype IN ('county', 'locality', 'localadmin')
       AND (
-        REPLACE(name_primary, ' ', '') ILIKE REPLACE('{city}', ' ', '')
+        REPLACE(name_primary, ' ', '') ILIKE REPLACE($city, ' ', '')
         OR
-        REPLACE(name_en, ' ', '') ILIKE REPLACE('{city}', ' ', '')
+        REPLACE(name_en, ' ', '') ILIKE REPLACE($city, ' ', '')
     )
 """
 
 CITY_NO_REGION = """
     SELECT {columns} FROM {table}
-    WHERE country ILIKE '{country}'
+    WHERE country ILIKE $country
       AND subtype IN ('county', 'locality', 'localadmin')
       AND (
-        REPLACE(name_primary, ' ', '') ILIKE REPLACE('{city}', ' ', '')
+        REPLACE(name_primary, ' ', '') ILIKE REPLACE($city, ' ', '')
         OR
-        REPLACE(name_en, ' ', '') ILIKE REPLACE('{city}', ' ', '')
+        REPLACE(name_en, ' ', '') ILIKE REPLACE($city, ' ', '')
     )
 """
 
@@ -117,7 +117,7 @@ CITY_NO_REGION = """
 
 REGIONS_LIST = """
     SELECT * FROM wkls
-    WHERE country = '{country}'
+    WHERE country = $country
       AND subtype = 'region'
 """
 
@@ -139,14 +139,14 @@ SUBTYPES_LIST = """
 
 SUBDIVISIONS = """
     SELECT * FROM wkls
-    WHERE country = '{country}'
-      AND region = '{region}'
+    WHERE country = $country
+      AND region = $region
       AND subtype IN {subtype_filter}
 """
 
 SUBDIVISIONS_NO_REGION = """
     SELECT * FROM wkls
-    WHERE country = '{country}'
+    WHERE country = $country
       AND subtype IN {subtype_filter}
 """
 
@@ -158,8 +158,8 @@ SUGGEST_COUNTRY = """
     FROM wkls
     WHERE subtype = 'country'
       AND (
-        LOWER(country) LIKE '{search_term}%'
-        OR '{search_term}' LIKE LOWER(country) || '%'
+        LOWER(country) LIKE $search_term || '%'
+        OR $search_term LIKE LOWER(country) || '%'
       )
     ORDER BY chainable_name ASC
     LIMIT {limit}
@@ -169,11 +169,11 @@ SUGGEST_COUNTRY = """
 SUGGEST_REGION = """
     SELECT DISTINCT LOWER(SPLIT_PART(region, '-', 2)) as chainable_name
     FROM wkls
-    WHERE country = '{country}'
+    WHERE country = $country
       AND subtype = 'region'
       AND (
-        LOWER(SPLIT_PART(region, '-', 2)) LIKE '{search_term}%'
-        OR '{search_term}' LIKE LOWER(SPLIT_PART(region, '-', 2)) || '%'
+        LOWER(SPLIT_PART(region, '-', 2)) LIKE $search_term || '%'
+        OR $search_term LIKE LOWER(SPLIT_PART(region, '-', 2)) || '%'
       )
     ORDER BY chainable_name ASC
     LIMIT {limit}
@@ -222,7 +222,7 @@ DIR_REGIONS = f"""
       LOWER(SPLIT_PART(region, '-', 2)) AS iso,
       {_CHAINABLE_NAME_EXPR}            AS name
     FROM wkls
-    WHERE country = '{{country}}'
+    WHERE country = $country
       AND subtype = 'region'
 """
 
@@ -235,8 +235,8 @@ DIR_REGIONS = f"""
 # (e.g. ``search("sanfrancisco")`` finds "San Francisco"). The query is
 # pre-normalized in Python before substitution.
 _SEARCH_NAME_MATCH = (
-    "LOWER(REGEXP_REPLACE(name_primary, '[^a-zA-Z0-9]', '', 'g')) LIKE '%{query}%'\n"
-    "      OR LOWER(REGEXP_REPLACE(name_en, '[^a-zA-Z0-9]', '', 'g')) LIKE '%{query}%'"
+    "LOWER(REGEXP_REPLACE(name_primary, '[^a-zA-Z0-9]', '', 'g')) LIKE '%' || $query || '%'\n"
+    "      OR LOWER(REGEXP_REPLACE(name_en, '[^a-zA-Z0-9]', '', 'g')) LIKE '%' || $query || '%'"
 )
 
 SEARCH_ROOT = f"""
@@ -249,7 +249,7 @@ SEARCH_ROOT = f"""
 SEARCH_COUNTRY = f"""
     SELECT DISTINCT id, country, region, subtype, name_primary, name_en, parent_id
     FROM wkls
-    WHERE country = '{{country}}'
+    WHERE country = $country
       AND (
         {_SEARCH_NAME_MATCH}
       )
@@ -259,8 +259,8 @@ SEARCH_COUNTRY = f"""
 SEARCH_REGION = f"""
     SELECT DISTINCT id, country, region, subtype, name_primary, name_en, parent_id
     FROM wkls
-    WHERE country = '{{country}}'
-      AND region = '{{region}}'
+    WHERE country = $country
+      AND region = $region
       AND (
         {_SEARCH_NAME_MATCH}
       )
@@ -278,18 +278,18 @@ SEARCH_WITHIN_VIEW = f"""
 """
 
 # For city-level suggestions (Levenshtein fuzzy matching)
-# Use {region_filter} = "AND region = '{region}'" or "" for countries without regions
+# Use {region_filter} = "AND region = $region" or "" for countries without regions
 SUGGEST_CITY = f"""
     SELECT DISTINCT
            {_CHAINABLE_NAME_EXPR} as chainable_name,
            CASE
-             WHEN {_CHAINABLE_NAME_EXPR} = '{{search_term}}' THEN 0
-             WHEN {_CHAINABLE_NAME_EXPR} LIKE '{{search_term}}%' THEN 1
-             WHEN {_CHAINABLE_NAME_EXPR} LIKE '%{{search_term}}%' THEN 2
-             ELSE levenshtein({_CHAINABLE_NAME_EXPR}, '{{search_term}}') + 10
+             WHEN {_CHAINABLE_NAME_EXPR} = $search_term THEN 0
+             WHEN {_CHAINABLE_NAME_EXPR} LIKE $search_term || '%' THEN 1
+             WHEN {_CHAINABLE_NAME_EXPR} LIKE '%' || $search_term || '%' THEN 2
+             ELSE levenshtein({_CHAINABLE_NAME_EXPR}, $search_term) + 10
            END as distance
     FROM wkls
-    WHERE country = '{{country}}'
+    WHERE country = $country
       {{region_filter}}
       AND subtype IN ('county', 'locality', 'localadmin')
     ORDER BY distance ASC, chainable_name ASC


### PR DESCRIPTION
## Summary

- Move `_METHOD_FOR_SUBTYPE` to module scope (was rebuilt every call) and fix stale docstring referencing removed `.resolve()`
- Deduplicate `configure()` by delegating to `_ensure_overture_loaded(force=True)`
- Replace all SQL string interpolation with SedonaDB parameterized queries (`$param` syntax), removing the `sqlescapy` dependency
- Remove 6 unused query templates from `queries.py`

All 218 tests pass.