### PR TITLE
fix: agent-usability follow-ups from the 1.3.0 audit

### DIFF
--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -296,3 +296,9 @@ def test_exception_class_is_exported_at_package_level():
     """``except wkls.AmbiguousLocationError`` must catch, not drill a chain."""
     assert wkls.AmbiguousLocationError is wkls.core.AmbiguousLocationError
     assert issubclass(wkls.AmbiguousLocationError, ValueError)
+
+
+def test_result_mode_ambiguity_names_the_row_count():
+    """No 'this result' placeholder; say how many rows there are."""
+    with pytest.raises(wkls.AmbiguousLocationError, match="58 rows in this result"):
+        wkls.us.ca.counties().wkt()

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -277,3 +277,22 @@ def test_result_mode_dir_omits_subtype_names():
         assert subtype not in entries, (
             f"dir() should not advertise subtype '{subtype}' as a narrower"
         )
+
+
+def test_ambiguous_error_carries_candidates():
+    """``err.candidates`` is the multi-row Wkl — no message parsing needed."""
+    with pytest.raises(wkls.AmbiguousLocationError) as exc_info:
+        wkls.us.pa.york.wkt()
+    candidates = exc_info.value.candidates
+    assert len(candidates) == 2
+    assert all(
+        "york" in (r["name_en"] or r["name_primary"]).lower()
+        for r in candidates.to_dicts()
+    )
+    assert candidates.to_dicts()[0]["id"] in str(exc_info.value)
+
+
+def test_exception_class_is_exported_at_package_level():
+    """``except wkls.AmbiguousLocationError`` must catch, not drill a chain."""
+    assert wkls.AmbiguousLocationError is wkls.core.AmbiguousLocationError
+    assert issubclass(wkls.AmbiguousLocationError, ValueError)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -605,3 +605,19 @@ def test_counties_at_county_level_includes_self():
     rows = counties.to_dicts()
     assert rows[0]["name_primary"] == "San Francisco"
     assert rows[0]["subtype"] == "county"
+
+
+def test_root_dir_lists_every_listing_method_and_the_exception():
+    entries = dir(wkls)
+    for name in (
+        "countries",
+        "dependencies",
+        "regions",
+        "counties",
+        "cities",
+        "subtypes",
+        "search",
+        "by_id",
+        "AmbiguousLocationError",
+    ):
+        assert name in entries, name

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -200,3 +200,10 @@ def test_search_on_an_empty_scope_raises_the_chain_hint():
         wkls.zz.search("london")
     with pytest.raises(ValueError, match="No results found for: us.ca.sanfransisco"):
         wkls.us.ca.sanfransisco.search("x")
+
+
+def test_far_suggestions_are_dropped():
+    """Only near misses are suggested; 'sananselmo' is five edits away."""
+    r = repr(wkls.us.ca.sanfransisco)
+    assert "sanfrancisco" in r
+    assert "sananselmo" not in r

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -156,3 +156,47 @@ def test_chainable_df_hides_root_only_config_methods():
     us = wkls.us
     for name in ("configure", "overture_version", "overture_releases"):
         assert not hasattr(us, name), f"{name} should be hidden on chained Wkl"
+
+
+# ---------- Wrong-guess paths ----------
+
+
+def test_call_on_misspelled_method_names_the_closest_method():
+    """``wkls.us.wktt()`` names ``.wkt()`` instead of a bare 'not callable'."""
+    with pytest.raises(TypeError, match=r"Did you mean \.wkt\(\)"):
+        wkls.us.wktt()
+    with pytest.raises(TypeError, match=r"Did you mean \.countries\(\)"):
+        wkls.countrie()
+
+
+def test_call_on_a_real_place_says_drop_the_parentheses():
+    with pytest.raises(TypeError, match=r"drop the parentheses \(wkls\.us\)"):
+        wkls.us()
+
+
+def test_field_attribute_redirects_to_to_dicts():
+    """Row fields are read via to_dicts(), and the error says so."""
+    row = wkls.us.tn.search("franklin")[0]
+    with pytest.raises(AttributeError, match=r"to_dicts\(\)\[0\]\['name_primary'\]"):
+        _ = row.name_primary
+    with pytest.raises(AttributeError, match=r"to_dicts\(\)\[0\]\['name_en'\]"):
+        _ = row.name
+    with pytest.raises(AttributeError, match=r"\.wkt\(\)"):
+        _ = row.geometry
+
+
+def test_search_rejects_non_string_and_empty_queries():
+    with pytest.raises(TypeError, match="str query"):
+        wkls.search(123)
+    with pytest.raises(ValueError, match="non-empty"):
+        wkls.search("")
+    with pytest.raises(ValueError, match="non-empty"):
+        wkls.us.search("  - ")
+
+
+def test_search_on_an_empty_scope_raises_the_chain_hint():
+    """``wkls.zz.search('x')`` used to return a silent ``Wkl(rows=0)``."""
+    with pytest.raises(ValueError, match="No results found for: zz"):
+        wkls.zz.search("london")
+    with pytest.raises(ValueError, match="No results found for: us.ca.sanfransisco"):
+        wkls.us.ca.sanfransisco.search("x")

--- a/tests/test_pythonic.py
+++ b/tests/test_pythonic.py
@@ -19,6 +19,8 @@ validates.
 
 from __future__ import annotations
 
+import typing
+
 import pyarrow as pa
 import pytest
 import sedonadb
@@ -406,3 +408,10 @@ def test_redirect_fires_on_chain_mode():
     """Known DataFrame verbs redirect even on chain-mode Wkls."""
     with pytest.raises(AttributeError, match="search"):
         wkls.us.ca.filter  # noqa: B018
+
+
+def test_geometry_methods_have_resolvable_type_hints():
+    """Tool-schema generators call get_type_hints(); the mixin's hints must resolve."""
+    for name in ("wkt", "wkb", "geojson", "search", "to_dicts", "to_arrow_table"):
+        hints = typing.get_type_hints(getattr(wkls.Wkl, name))
+        assert "return" in hints, name

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -340,3 +340,22 @@ def test_depth3_search_scope_is_children_even_after_repr():
     w = wkls.us.pa.yorkcounty
     repr(w)
     assert len(w.search("york")) == fresh > 1
+
+
+# ---------- repr hygiene ----------
+
+
+def test_repr_marks_truncated_rows():
+    """Header says rows=N, the table shows 10, the footer says how many more."""
+    r = repr(wkls.us.regions())
+    assert r.splitlines()[0] == "Wkl(rows=51, subtype='region')"
+    assert "41 more rows not shown" in r
+    assert "more rows" not in repr(wkls.us.ca.sanfrancisco)
+
+
+def test_empty_repr_has_no_table_frame():
+    """An empty result is header + hint; no empty table frame."""
+    r = repr(wkls.us.ca.sanfransisco)
+    assert "┌" not in r
+    assert "Did you mean: sanfrancisco" in r
+    assert repr(wkls.us.ca.search("zzznope")) == "Wkl(rows=0)"

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -359,3 +359,18 @@ def test_empty_repr_has_no_table_frame():
     assert "┌" not in r
     assert "Did you mean: sanfrancisco" in r
     assert repr(wkls.us.ca.search("zzznope")) == "Wkl(rows=0)"
+
+
+def test_module_docstring_covers_agent_traps():
+    """help() must describe the real Arrow schema and the cost of geometry."""
+    doc = wkls.__doc__ or ""
+    for needle in (
+        "names.primary",
+        "not cached",
+        "getattr(wkls, 'in')",
+        "subtypes()",
+        "WKLS_DEBUG",
+        "san_francisco",
+    ):
+        assert needle in doc, needle
+    assert "list(wkl), tuple(wkl)" not in doc

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -316,3 +316,27 @@ def test_nonexistent_location_returns_empty():
 
     # ZZ is not a valid US state code
     assert wkls.us.zz._resolve().count() == 0
+
+
+# ---------- Attribute spellings agents actually use ----------
+
+
+def test_underscored_place_name_resolves():
+    """``san_francisco`` is the natural spelling; separators are stripped."""
+    assert wkls.us.ca.san_francisco.to_dicts()[0]["name_en"] == "San Francisco"
+    assert wkls.us.ca.san_francisco.path == wkls.us.ca.sanfrancisco.path
+
+
+def test_root_country_aliases():
+    """Colloquial codes that are not ISO alpha-2 resolve at the root."""
+    assert wkls.uk.to_dicts()[0]["country"] == "GB"
+    assert wkls.usa.to_dicts()[0]["country"] == "US"
+    assert wkls.uae.to_dicts()[0]["country"] == "AE"
+
+
+def test_depth3_search_scope_is_children_even_after_repr():
+    """Regression: a cached ``_df`` made search narrow the county row itself."""
+    fresh = len(wkls.us.pa.yorkcounty.search("york"))
+    w = wkls.us.pa.yorkcounty
+    repr(w)
+    assert len(w.search("york")) == fresh > 1

--- a/wkls/__init__.py
+++ b/wkls/__init__.py
@@ -105,9 +105,9 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-from .core import Wkl
+from .core import AmbiguousLocationError, Wkl
 
-__all__ = ["Wkl"]
+__all__ = ["AmbiguousLocationError", "Wkl"]
 
 
 # Intentionally shadows the builtin at module level so ``wkls.help()``

--- a/wkls/__init__.py
+++ b/wkls/__init__.py
@@ -18,6 +18,10 @@ Chain depth maps to the admin hierarchy (max 3 for unambiguous cases):
 
 Names are lowercased with non-alphanumerics stripped; ISO codes work
 too: wkls.us, wkls.unitedstates, wkls.us.ca, wkls.us.california.
+Underscores are ignored (wkls.us.ca.san_francisco). ISO codes that are
+Python keywords (in, is, or, as) need the name or getattr:
+wkls.india, wkls.us.oregon, getattr(wkls, 'in'). The colloquial codes
+uk, usa and uae resolve at the root.
 
 Resolving ambiguity — when a chain resolves to >1 row, geometry
 methods raise AmbiguousLocationError (a ValueError subclass) with a
@@ -48,17 +52,25 @@ Every call returns a Wkl — one unified type. Inspect like any Python
 sequence:
 
     len(wkl)                               # row count
-    for row in wkl: row.wkt()              # iterate; each row is a Wkl
+    for row in wkl: row.to_dicts()[0]      # iterate; each row is a 1-row Wkl
     wkl[0], wkl[-1]                        # positional index
     wkl[:5]                                # slice; returns a multi-row Wkl
     '<uuid>' in wkl                        # id-column membership check
-    list(wkl), tuple(wkl)                  # standard collection conversions
+
+Printing a multi-row Wkl shows 10 rows plus a "more rows" footer. Do
+not print list(wkl) or each row in a loop: every 1-row Wkl reprs as a
+full table (~600 chars), so 722 cities is ~450K chars. Use .to_dicts().
 
 Also available: .to_dicts() (metadata-only), .to_arrow_table() (with
 geometry, GeoArrow WKB). For DataFrame ops beyond admin-boundary lookup
 (.filter, .join, .group_by, …), call .to_arrow_table() and use your
 engine of choice (GeoPandas, DuckDB, Polars, etc.). Extract geometry
 with .wkt() / .wkb() / .geojson() when the Wkl holds exactly one row.
+
+Geometry cost — each .wkt() / .wkb() / .geojson() call is a 2–10 s fetch
+from Overture on S3 and is not cached. Output runs from ~20 KB (a city)
+to >1 MB (a large state); check len() before printing. For more than
+one row, call .to_arrow_table() once instead of looping.
 
 Navigation — .parent walks up one level; .path returns the canonical
 dot-chain string that round-trips via eval:
@@ -72,6 +84,7 @@ Listing — scopes narrow with chain depth:
     wkls.us.regions()                      # 51 US regions
     wkls.us.ca.counties()                  # 58 CA counties
     wkls.us.ca.sandiegocounty.cities()     # 19 localities in SD County
+    wkls.us.tx.subtypes()                  # which subtypes exist in scope
 
 Two ways to use the library (equivalent):
 
@@ -88,17 +101,19 @@ Configuration — wkls defaults to the latest Overture Maps release:
     wkls.overture_version()                # current version string
     wkls.configure(overture_version='2026-07-22.0')
     WKLS_OVERTURE_VERSION=2026-07-22.0     # env var, checked at import
+    WKLS_DEBUG=1                           # env var: print every SQL query
 
-Arrow schema — wkl.to_arrow_table() returns these columns:
+Columns — .to_dicts() returns flat rows with these keys:
 
-    id            string     Overture feature ID (UUID)
-    country       string     ISO 3166-1 alpha-2 code
-    region        string     region name (state / province)
-    subtype       string     country | dependency | region | county | locality | localadmin
-    name_primary  string     primary display name
-    name_en       string     English name (may equal name_primary)
-    parent_id     string     parent feature ID
-    geometry      GeoArrow WKB (OGC:CRS84)
+    id, country, region, subtype, name_primary, name_en, parent_id
+    (subtype is one of country | dependency | region | county | locality | localadmin)
+
+.to_arrow_table() returns the full Overture division_area schema (14
+columns: id, country, region, subtype, names, sources, admin_level,
+class, is_land, is_territorial, division_id, version, bbox, geometry).
+The display name is names.primary (a struct), not name_primary; the
+geometry column is GeoArrow WKB (OGC:CRS84). Hand it to GeoPandas,
+DuckDB or Polars.
 """
 
 from __future__ import annotations

--- a/wkls/_geometry.py
+++ b/wkls/_geometry.py
@@ -66,7 +66,7 @@ class _GeometryMixin:
             raise ValueError("No rows to resolve into a geometry.")
 
         if row_count > 1:
-            raise AmbiguousLocationError(self._ambiguity_message(df))
+            raise AmbiguousLocationError(self._ambiguity_message(df), candidates=self)
 
         row = df.head(1).to_arrow_table()
         gers_id = row.column("id")[0].as_py()

--- a/wkls/_geometry.py
+++ b/wkls/_geometry.py
@@ -118,7 +118,11 @@ class _GeometryMixin:
         )
 
     def wkt(self: Wkl) -> str:
-        """Get Well-Known Text (WKT) geometry for the first result.
+        """Get Well-Known Text (WKT) geometry for a single-row Wkl.
+
+        Fetches from Overture on S3 (2–10 s, not cached). Output can run
+        to more than 1 MB for a large state; check ``len()`` before
+        printing. For many rows call ``to_arrow_table()`` once instead.
 
         Returns:
             WKT string representation of the geometry.
@@ -130,7 +134,11 @@ class _GeometryMixin:
         return self._get_geom_expr("ST_AsText(geometry)")
 
     def wkb(self: Wkl) -> bytes:
-        """Get Well-Known Binary (WKB) geometry for the first result.
+        """Get Well-Known Binary (WKB) geometry for a single-row Wkl.
+
+        Fetches from Overture on S3 (2–10 s, not cached). Output can run
+        to more than 1 MB for a large state; check ``len()`` before
+        printing. For many rows call ``to_arrow_table()`` once instead.
 
         Returns:
             Binary WKB representation of the geometry.
@@ -142,7 +150,11 @@ class _GeometryMixin:
         return self._get_geom_expr("ST_AsWKB(geometry)")
 
     def geojson(self: Wkl) -> str:
-        """Get GeoJSON geometry for the first result.
+        """Get GeoJSON geometry for a single-row Wkl.
+
+        Fetches from Overture on S3 (2–10 s, not cached). Output can run
+        to more than 1 MB for a large state; check ``len()`` before
+        printing. For many rows call ``to_arrow_table()`` once instead.
 
         Returns:
             GeoJSON string representation of the geometry.

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -27,7 +27,7 @@ from typing import Any
 import pyarrow as pa
 import sedonadb
 
-from . import _bootstrap, queries
+from . import _bootstrap, _geometry, queries
 from ._geometry import _GeometryMixin
 from ._version import _list_s3_releases, _resolve_overture_version
 
@@ -1522,8 +1522,13 @@ class Wkl(_GeometryMixin):
         instead.
 
         Returns:
-            pyarrow.Table with metadata columns plus a 'geometry' column
-            typed as ``geoarrow.wkb<OGC:CRS84>``.
+            pyarrow.Table with the full Overture division_area schema —
+            id, country, region, subtype, names, sources, admin_level,
+            class, is_land, is_territorial, division_id, version, bbox —
+            plus 'geometry' typed as ``geoarrow.wkb<OGC:CRS84>``. The
+            display name is ``names.primary`` (a struct field); the flat
+            ``name_primary`` / ``name_en`` / ``parent_id`` keys exist only
+            on ``to_dicts()``.
 
         Raises:
             ValueError: If the chain is empty and no cached DataFrame is
@@ -2081,3 +2086,9 @@ def _wkl_from_arrow_slice(table: pa.Table) -> Wkl:
     ``_df`` for downstream ``.wkt()`` / ``.path`` / ``.parent`` calls.
     """
     return Wkl(_df=_bootstrap.sedona.create_data_frame(table))
+
+
+# Let ``typing.get_type_hints()`` resolve the geometry mixin's ``self: Wkl``
+# annotations at runtime: tool-schema generators (pydantic, LangChain) call
+# it on exactly wkt/wkb/geojson, and the mixin imports Wkl for mypy only.
+_geometry.Wkl = Wkl  # type: ignore[attr-defined]

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -19,6 +19,7 @@ Example usage:
 
 from __future__ import annotations
 
+import difflib
 import re
 from collections.abc import Callable, Iterator
 from typing import Any
@@ -71,10 +72,18 @@ class AmbiguousLocationError(ValueError):
     keep catching it. The message lists every candidate with its subtype,
     parent name, and id, and points at the dot-based disambiguation paths:
 
-    - subtype modifier: ``wkls.us.ca.mission.locality``
+    - subtype filter on the result: ``wkls.us.ca.search('mission').cities()``
     - 4-level parent narrower: ``wkls.us.pa.adamscounty.franklin``
     - exact pick: ``wkls.by_id('<uuid>')``
+
+    ``candidates`` holds the multi-row ``Wkl`` that raised, so callers can
+    recover programmatically (``err.candidates.to_dicts()``,
+    ``err.candidates[0].wkt()``) instead of parsing the message.
     """
+
+    def __init__(self, message: str, candidates: Wkl | None = None) -> None:
+        super().__init__(message)
+        self.candidates = candidates
 
 
 # Methods surfaced by __dir__ at each chain depth.
@@ -192,7 +201,48 @@ _S3_REDIRECTS: dict[str, str] = {
     "unique": "Use 'wkl.to_arrow_table()' and your engine of choice.",
 }
 
-_GENERIC_FALLBACK = "Use 'wkl.to_arrow_table()' and your engine of choice."
+_GENERIC_FALLBACK = (
+    "Row fields: wkl.to_dicts()[0]['name_en'] (keys: id, country, region, "
+    "subtype, name_primary, name_en, parent_id). Geometry: .wkt(), .wkb(), "
+    ".geojson(). Anything else: wkl.to_arrow_table() and your engine of choice."
+)
+
+# Colloquial country codes that are not ISO 3166-1 alpha-2. Applied at the
+# root only, where nothing but countries and dependencies resolve, so the
+# Russian locality "Uk" and the Japanese county "Usa" stay reachable through
+# their own chains.
+_COUNTRY_ALIASES: dict[str, str] = {"uk": "gb", "usa": "us", "uae": "ae"}
+
+# Row-field names agents reach for as attributes on a single-row Wkl. None of
+# them normalizes to a place name in the bundle, so redirecting is safe.
+_FIELD_REDIRECTS: frozenset[str] = frozenset(
+    {
+        "name",
+        "names",
+        "name_primary",
+        "name_en",
+        "subtype",
+        "country",
+        "region",
+        "parent_id",
+        "geometry",
+    }
+)
+
+
+def _field_redirect(attr: str) -> str:
+    """Explain how to read a row field that was accessed as an attribute."""
+    if attr == "geometry":
+        return (
+            "Geometry comes from .wkt(), .wkb() or .geojson() on a single-row "
+            "Wkl, or from .to_arrow_table() for many rows."
+        )
+    key = {"name": "name_en", "names": "name_primary"}.get(attr, attr)
+    return (
+        f"Read row fields with wkl.to_dicts()[0]['{key}'] "
+        "(keys: id, country, region, subtype, name_primary, name_en, parent_id)."
+    )
+
 
 # Listing methods that narrow a multi-row result to a single subtype
 # (or inspect what subtypes are present). Surfaced via ``dir()`` on a
@@ -836,9 +886,10 @@ class Wkl(_GeometryMixin):
 
         1. Private/dunder attributes → ``AttributeError``.
         2. Root-only methods → ``AttributeError``.
-        3. Redirect tables (S1 → S2 → S3) → ``AttributeError`` with
-           suggestion.
-        4. Chain drill (alphanumeric location identifier) → new ``Wkl``.
+        3. Row-field names and redirect tables (S1 → S2 → S3) →
+           ``AttributeError`` naming the right call.
+        4. Chain drill (location identifier, underscores stripped, root
+           aliases ``uk``/``usa``/``uae`` applied) → new ``Wkl``.
         5. Generic fallback → ``AttributeError``.
 
         Raises:
@@ -861,6 +912,13 @@ class Wkl(_GeometryMixin):
                 f"'{self.__class__.__name__}' object has no attribute '{attr}'"
             )
 
+        # Row fields are not attributes; say where they live instead of
+        # drilling "name_primary" into the chain as a place name.
+        if attr in _FIELD_REDIRECTS:
+            raise AttributeError(
+                f"'{attr}' is not a Wkl attribute. {_field_redirect(attr)}"
+            )
+
         # Redirect check — must fire before chain drill so that known
         # non-location attrs (e.g. .filter) don't silently extend the chain.
         for table in (_S1_REDIRECTS, _S2_REDIRECTS, _S3_REDIRECTS):
@@ -873,8 +931,14 @@ class Wkl(_GeometryMixin):
         # identifiers (alphanumeric). Result-mode Wkls (no chain, have
         # _df) skip drill — they have no tree position.
         if self.chain or self._df is None:
-            if attr.isalnum():
-                new_chain = self.chain + [attr.lower()]
+            # Attribute names can't hold spaces, so agents write
+            # ``san_francisco``; the bundle's normalized form has no
+            # separators at all. Strip underscores before matching.
+            token = attr.replace("_", "").lower()
+            if not self.chain:
+                token = _COUNTRY_ALIASES.get(token, token)
+            if token.isalnum():
+                new_chain = self.chain + [token]
                 if len(new_chain) > 4:
                     raise ValueError(
                         "Chain too deep (max = 4). Use .by_id('<uuid>') for specific rows."
@@ -897,6 +961,32 @@ class Wkl(_GeometryMixin):
 
         raise AttributeError(
             f"'{attr}' is not part of the Wkl API. {_GENERIC_FALLBACK}"
+        )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Explain a call on a ``Wkl`` instead of a bare "not callable".
+
+        A misspelled method (``wkls.us.wktt()``) is read as a place name
+        first, so the parentheses land here. Name the closest public
+        method so the caller can fix the typo in one step.
+        """
+        methods = sorted(
+            n
+            for n in dir(type(self))
+            if not n.startswith("_") and callable(getattr(type(self), n))
+        )
+        token = self.chain[-1] if self.chain else ""
+        where = "wkls." + ".".join(self.chain) if self.chain else "this Wkl"
+        close = difflib.get_close_matches(token, methods, n=1, cutoff=0.6)
+        if close:
+            raise TypeError(
+                f"'{token}' is not a Wkl method; it was read as a place name "
+                f"({where}). Did you mean .{close[0]}()? "
+                f"Wkl methods: {', '.join(methods)}."
+            )
+        raise TypeError(
+            f"Wkl is not callable; drop the parentheses ({where}). "
+            f"Wkl methods: {', '.join(methods)}."
         )
 
     def __dir__(self) -> list[str]:
@@ -1873,6 +1963,12 @@ class Wkl(_GeometryMixin):
         Returns:
             A result-mode ``Wkl`` of matching rows.
 
+        Raises:
+            TypeError: If ``query`` is not a string.
+            ValueError: If ``query`` has no letters or digits, or the chain
+                itself matches no rows (the message carries the same
+                "did you mean" hint as the chain's repr).
+
         Examples:
             >>> import wkls
             >>> wkls.search("san francisco")              # full dataset
@@ -1880,18 +1976,35 @@ class Wkl(_GeometryMixin):
             >>> wkls.us.ca.search("san")                  # scoped to CA
             >>> wkls.us.ca.search("san").search("fran")   # narrow within
         """
+        if not isinstance(query, str):
+            raise TypeError(f"search() takes a str query, got {type(query).__name__}.")
         depth = len(self.chain)
+        result_mode = depth == 0 and self._df is not None
 
         # Normalize to the dot-access form so ``search("sanfrancisco")``
         # and ``search("San Francisco")`` both match "San Francisco".
         normalized_query = _normalize_name(query)
+        if not normalized_query:
+            raise ValueError(
+                "search() needs a non-empty query with at least one letter or digit."
+            )
+
+        # A chain that matches nothing has nothing to search within. Raise
+        # the hint its repr would show instead of returning a silent empty.
+        if self.chain and self._resolve().count() == 0:
+            raise ValueError(
+                _build_error_hint(
+                    self.chain, self._get_suggestions(self.chain[-1])
+                ).strip()
+            )
 
         # Depth > 2 or result-mode: resolve to a temp view and search
         # within it. For chain-mode at depth > 2 (e.g. wkls.us.pa.yorkcounty),
-        # search the county's cities rather than the county row itself.
-        if depth > 2 or (depth == 0 and self._df is not None):
+        # search the county's cities rather than the county row itself —
+        # decided by the chain, not by whether ``_df`` happens to be cached.
+        if depth > 2 or result_mode:
             view_name = "_wkls_search_within"
-            if self._df is not None:
+            if result_mode:
                 # Result-mode: narrow within existing rows.
                 resolved = self._df
             else:

--- a/wkls/core.py
+++ b/wkls/core.py
@@ -91,9 +91,12 @@ _DIR_ROOT_METHODS = frozenset(
     {
         "Wkl",
         "by_id",
+        "cities",
         "configure",
+        "counties",
         "countries",
         "dependencies",
+        "regions",
         "overture_releases",
         "overture_version",
         "search",
@@ -251,6 +254,10 @@ def _field_redirect(attr: str) -> str:
 _DIR_RESULT_NARROW_METHODS = frozenset(
     {"cities", "counties", "countries", "dependencies", "regions", "subtypes"}
 )
+
+# Rows sedonadb's DataFrame repr prints before cutting off (its ``show``
+# default). Used to append an explicit "more rows" marker.
+_REPR_ROWS = 10
 
 # Surface 2 error messages. Kept at module scope so tests can pattern-match
 # a stable substring without coupling to the exact full text.
@@ -564,9 +571,12 @@ class Wkl(_GeometryMixin):
         .county' hint that may not apply. Always lists ``by_id(...)``
         for every candidate as the guaranteed fallback.
         """
-        where = "wkls." + ".".join(self.chain) if self.chain else "this result"
         table = df.to_arrow_table()
         n = table.num_rows
+        if self.chain:
+            subject = f"{n} matches for 'wkls.{'.'.join(self.chain)}'"
+        else:
+            subject = f"{n} rows in this result"
         sample = min(n, 10)
 
         candidates = _group_candidates(table, self._fetch_row, sample)
@@ -592,18 +602,14 @@ class Wkl(_GeometryMixin):
         )
 
         if self.chain and attrs_differ:
-            lines.append(
-                f"{n} matches for '{where}'. Use the unambiguous normalized name:"
-            )
+            lines.append(f"{subject}. Use the unambiguous normalized name:")
             lines.append("")
             for c in candidates:
                 lines.append(
                     f"  {chain_prefix}.{c['attr']:<18}  # {c['name']} ({c['subtype']})"
                 )
         elif self.chain and parents_differ:
-            lines.append(
-                f"{n} matches for '{where}'. Narrow by parent (4-level chain):"
-            )
+            lines.append(f"{subject}. Narrow by parent (4-level chain):")
             lines.append("")
             for c in candidates:
                 parent_label = c["parent_name"] or c["parent_attr"] or "?"
@@ -615,7 +621,7 @@ class Wkl(_GeometryMixin):
         else:
             # Same attr + same parent (or no chain to narrow) — dot
             # paths can't distinguish these.
-            lines.append(f"{n} matches for '{where}'. Narrow with one of:")
+            lines.append(f"{subject}. Narrow with one of:")
 
         # Subtype narrowing — applies whenever candidates span multiple
         # subtype *groups* (two rows both in ``locality`` don't get a
@@ -1241,6 +1247,19 @@ class Wkl(_GeometryMixin):
             return "Wkl(root)"
 
         df = self._resolve()
+        subtypes = self._subtype_counts()
+        header = self._repr_header(subtypes)
+        row_count = sum(subtypes.values())
+
+        if row_count == 0:
+            # No table frame for an empty result: the header already says
+            # rows=0, and the hint says what to try next.
+            if self.chain:
+                suggestions = self._get_suggestions(self.chain[-1])
+                hint = _build_error_hint(self.chain, suggestions)
+                return f"{header}\n{hint}".rstrip()
+            return header
+
         # Drop parent_id from repr — it's a raw UUID that adds noise.
         # Users who need it can call .to_dicts() or .to_arrow_table().
         cols = [c for c in df.columns if c != "parent_id"]
@@ -1252,24 +1271,27 @@ class Wkl(_GeometryMixin):
         # UUID columns aren't truncated. Going through ``repr()`` keeps us
         # on the public sedonadb API.
         base_repr = repr(display_df)
-        header = self._repr_header()
 
-        if self.chain:
-            is_empty = df.count() == 0
-            if is_empty:
-                suggestions = self._get_suggestions(self.chain[-1])
-                hint = _build_error_hint(self.chain, suggestions) + "\n"
-                return f"{header}\n{hint}{base_repr}"
+        if row_count > _REPR_ROWS:
+            # sedonadb prints the first _REPR_ROWS rows with no marker; say
+            # so, or a reader assumes the table is complete.
+            return (
+                f"{header}\n{base_repr}\n"
+                f"… {row_count - _REPR_ROWS} more rows not shown. "
+                "Use wkl[i], wkl[:n], .to_dicts() or .search() to narrow."
+            )
         return f"{header}\n{base_repr}"
 
-    def _repr_header(self) -> str:
+    def _repr_header(self, subtypes: dict[str, int] | None = None) -> str:
         """One-line state header: path/chain, row count, subtype breakdown.
 
         Formatted so an agent inspecting a ``Wkl`` can see its mode and
         size at a glance. ``path=`` is used when the chain resolves to a
         single row (round-trippable); ``chain=`` is used otherwise.
+        ``subtypes`` lets ``__repr__`` share one count query.
         """
-        subtypes = self._subtype_counts()
+        if subtypes is None:
+            subtypes = self._subtype_counts()
         row_count = sum(subtypes.values())
 
         parts: list[str] = []
@@ -1386,7 +1408,7 @@ class Wkl(_GeometryMixin):
         return self._df
 
     def _get_suggestions(
-        self, failed_name: str, n: int = 5, max_distance: int = 15
+        self, failed_name: str, n: int = 5, max_distance: int = 12
     ) -> list[str]:
         """Get similar location names for "did you mean" suggestions.
 
@@ -1396,7 +1418,9 @@ class Wkl(_GeometryMixin):
         Args:
             failed_name: The name that wasn't found.
             n: Maximum number of suggestions to return.
-            max_distance: Maximum Levenshtein score for city-level (default 15).
+            max_distance: Maximum score for city-level suggestions (default
+                12: exact, prefix and substring matches plus up to two
+                edits; anything farther is noise, not a suggestion).
 
         Returns:
             List of chainable location names (lowercase, no spaces/special chars),


### PR DESCRIPTION
## Why

A fresh black-box agent review of the 1.3.0 wheel plus a white-box pass found that the happy path is solid but the wrong-guess paths are inconsistent: some guesses redirect precisely, some produce a silent empty result with unrelated suggestions, and misspelled methods die with a bare `TypeError`. Everything here is a few lines; no new features.

Stacked on #68 so it does not conflict with the release branch. Retarget to `main` once 1.3.0 merges.

## What changes for an agent

- `except wkls.AmbiguousLocationError` now catches. The name used to drill a chain and return a `Wkl`, so the `except` clause itself raised `TypeError`. The error also carries `.candidates` for programmatic recovery.
- `wkls.us.wktt()` says "Did you mean .wkt()?" instead of "'Wkl' object is not callable".
- `wkls.us.ca.san_francisco` resolves; `row.name_primary` points at `to_dicts()`; `wkls.uk` resolves to GB.
- `search()` rejects non-strings and empty queries, and raises the chain's own "No results found" hint when the scope matches nothing instead of a silent `Wkl(rows=0)`. A latent bug where a cached repr made depth-3 search narrow the county row instead of its cities is fixed too.
- Truncated reprs end with "… N more rows not shown"; empty reprs drop the empty table frame; did-you-mean stops suggesting names five edits away.
- `help()` describes the real Arrow schema, warns that geometry calls are uncached 2-10 s fetches with outputs up to >1 MB, and no longer advertises `list(wkl)`.
- `typing.get_type_hints(Wkl.wkt)` works, so tool-schema generators can wrap the geometry methods.

## Verification

Offline suite plus the disambiguation tests pass locally; the full suite runs in CI. Every behavior change has a test.
